### PR TITLE
Display code refactor II

### DIFF
--- a/main.css
+++ b/main.css
@@ -9,6 +9,7 @@ form {
 h1{
     margin: 10px;
 }
+
 header{
     border-bottom: black 1px solid;
     background: #728cb1;  /* fallback for old browsers */

--- a/user-profile.html
+++ b/user-profile.html
@@ -20,36 +20,40 @@
     </header>
     <h1>User Profile:</h1>
     <hgroup class="user-card">
-        <h2 class="id">ID: Wombat</h2>
-        <h3 class="name">Jason Ropp</h3>
+        <h2 class="name">Jason Ropp</h2>
+        <h3 class="id">ID: Wombat</h3>
         <h3 class="phone">541-615-9999</h3>
-        <h3 class="email"><a>dummy@email.com</a></h3>
+        <h3 class="email">
+            <a>dummy@email.com</a>
+        </h3>
         <button id="detailsButton" type="button" onclick='toggleUserDetails()'>Hide Details</button>
     </hgroup>
 </body>
 <script>
     function toggleUserDetails() {
 
-        var details = ['phone', 'email', 'id'];
-        for (let i = 0; i < details.length; i++) {
-            let elemClass = details[i];
-            let elem = document.getElementsByClassName(elemClass)[0];
-            
-            if (getComputedStyle(elem).display === "none") {
-                showElement(elem);
+        let userElems = Array.prototype.slice.call(event.target.parentNode.children);
+
+        for (let i = 0; i < userElems.length; i++) {
+            let elem = userElems[i];
+
+            if (elem.nodeName == "H3") {
+                toggleDisplay(elem);
             }
-            else if(getComputedStyle(elem).display === "block") {
-                hideElement(elem);
-            }
+
         }
     }
-    function hideElement(elem) {
-        elem.style.display = "none"
-        document.getElementById('detailsButton').textContent = "Show Details";
+
+    function toggleDisplay(elem) {
+
+        // Bug Fix: The first instance on page load does not register the display block style, even when added explicitly in main.css. 
+        if (elem.style.display === "") {
+            return elem.style.display = "none"
+        } else {
+            (elem.style.display == "block") ? elem.style.display = "none" : elem.style.display = "block";
+        }
     }
-    function showElement(elem) {
-        elem.style.display = "block"
-        document.getElementById('detailsButton').textContent = "Hide Details";
-    }
+   
 </script>
+
 </html>

--- a/user-profile.html
+++ b/user-profile.html
@@ -21,9 +21,9 @@
     <h1>User Profile:</h1>
     <hgroup class="user-card">
         <h2 class="id">ID: Wombat</h2>
-        <h2 class="name">Jason Ropp</h2>
-        <h2 class="phone">541-615-9999</h2>
-        <h2 class="email">dummy@email.com</h2>
+        <h3 class="name">Jason Ropp</h3>
+        <h3 class="phone">541-615-9999</h3>
+        <h3 class="email"><a>dummy@email.com</a></h3>
         <button id="detailsButton" type="button" onclick='toggleUserDetails()'>Hide Details</button>
     </hgroup>
 </body>

--- a/users-list.html
+++ b/users-list.html
@@ -24,22 +24,22 @@
     </h1>
     <ul>
         <li class="user-card">
-            <h2>ID: Wombat</h2>
             <h2 class="name">Jason</h2>
+            <h3>ID: Wombat</h3>
             <h3 class="phone">541-615-9999</h3>
-            <a class="email">dummy@email.com</a>
+            <h3 class="email"><a>dummy@email.com</a></h3>
         </li>
         <li class="user-card">
-            <h2>ID: Fox</h2>
             <h2 class="name">Carl</h2>
+            <h3>ID: Fox</h3>
             <h3 class="phone">531-225-9999</h3>
-            <a class="email">dummy@email.com</a>
+            <h3 class="email"><a>dummy@email.com</a></h3>
         </li>
         <li class="user-card">
-            <h2>ID: Snake</h2>
             <h2 class="name">Susanne</h2>
+            <h3>ID: Snake</h3>
             <h3 class="phone">531-225-6666</h3>
-            <a class="email">dummy@email.com</a>
+            <h3 class="email"><a>dummy@email.com</a></h3>
         </li>
     </ul>
 

--- a/users-list.html
+++ b/users-list.html
@@ -23,23 +23,39 @@
         Users:
     </h1>
     <ul>
-        <li class="user-card">
-            <h2 class="name">Jason</h2>
-            <h3>ID: Wombat</h3>
-            <h3 class="phone">541-615-9999</h3>
-            <h3 class="email"><a>dummy@email.com</a></h3>
+       
+        <li>
+            <hgroup class="user-card">
+                <h2 class="name">Jason Ropp</h2>
+                <h3 class="id">ID: Wombat</h3>
+                <h3 class="phone">541-615-9999</h3>
+                <h3 class="email">
+                    <a>dummy@email.com</a>
+                </h3>
+                <button id="detailsButton" type="button" onclick='toggleUserDetails()'>Hide Details</button>
+            </hgroup>
         </li>
-        <li class="user-card">
-            <h2 class="name">Carl</h2>
-            <h3>ID: Fox</h3>
-            <h3 class="phone">531-225-9999</h3>
-            <h3 class="email"><a>dummy@email.com</a></h3>
+        <li>
+            <hgroup class="user-card">
+                <h2 class="name">Jason Ropp</h2>
+                <h3 class="id">ID: Wombat</h3>
+                <h3 class="phone">541-615-9999</h3>
+                <h3 class="email">
+                    <a>dummy@email.com</a>
+                </h3>
+                <button id="detailsButton" type="button" onclick='toggleUserDetails()'>Hide Details</button>
+            </hgroup>
         </li>
-        <li class="user-card">
-            <h2 class="name">Susanne</h2>
-            <h3>ID: Snake</h3>
-            <h3 class="phone">531-225-6666</h3>
-            <h3 class="email"><a>dummy@email.com</a></h3>
+        <li>
+            <hgroup class="user-card">
+                <h2 class="name">Jason Ropp</h2>
+                <h3 class="id">ID: Wombat</h3>
+                <h3 class="phone">541-615-9999</h3>
+                <h3 class="email">
+                    <a>dummy@email.com</a>
+                </h3>
+                <button id="detailsButton" type="button" onclick='toggleUserDetails()'>Hide Details</button>
+            </hgroup>
         </li>
     </ul>
 


### PR DESCRIPTION
Recreated version of #11 

Refactors the toggleUserDisplay function in user-profile.html 

```
 function toggleUserDetails() {

        let userElems = Array.prototype.slice.call(event.target.parentNode.children);

        for (let i = 0; i < userElems.length; i++) {
            let elem = userElems[i];

            if (elem.nodeName == "H3") {
                toggleDisplay(elem);
            }

        }
    }

    function toggleDisplay(elem) {

        // Bug Fix: The first instance on page load does not register the display block style, even when added explicitly in main.css. 
        if (elem.style.display === "") {
            return elem.style.display = "none"
        } else {
            (elem.style.display == "block") ? elem.style.display = "none" : elem.style.display = "block";
        }
    }
```

Also reformats the HTML layout of the 'user-card' in both user-profile.html and users-list.html (this is the template for all uses of the "user-card"
```
<hgroup class="user-card">
        <h2 class="name">Jason Ropp</h2>
        <h3 class="id">ID: Wombat</h3>
        <h3 class="phone">541-615-9999</h3>
        <h3 class="email">
            <a>dummy@email.com</a>
        </h3>
        <button id="detailsButton" type="button" onclick='toggleUserDetails()'>Hide Details</button>
</hgroup>
```