### PR TITLE
Collapse New User Card On Save

### DIFF
--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -423,7 +423,7 @@
           database.saveUser(user);
         }
 
-        this.resetFormState();
+        this.cancel(e);
       }
 
       toggleMode(e) {
@@ -439,9 +439,6 @@
       }
 
       toggleNewUserCardDisplay() {
-
-        // FIXME: Currently this targets form instead of the parent container. But things aren't getting through,
-        //  so maybe hidden/visible needs to target the parent for the class then get the child form in the css selector
         let card = this.shadowRoot.querySelector('#userCard');
         let name = card.className;
         let regexToReplace = this.isVisible ? /\shidden/ : /\svisible/;


### PR DESCRIPTION
## What It Does

In the save function I replaced this.resetFormState() with this.cancel() so that on save the new user card collapses. 

This was after a convo with Nathan Phillips that the persistent new user card was dominating the page rather than users list.

## How To Test

Create a new user and click save. The new user window should collapse.

## Notes/Caveats

None

