### PR TITLE
styled the popup message and added animation

### DIFF
--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -106,10 +106,6 @@
           height: 0px;
           width: 0px;
         }
-        75% {
-          height: 408px;
-          width: 450px;
-        }
         100% {
           height: auto;
           width: 450px;

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -53,7 +53,6 @@
         padding: 10px;
         text-align: center;
         opacity: 0;
-        transition: all 1.0s ease-in-out; 
         transform: translateY(100%);
         transition: all 600ms cubic-bezier(0.77, 0, 0.175, 1);
       }

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -40,17 +40,35 @@
       }
 
       .message-box {
+        background-color: #4caf50;
+        color: #eef1f4;
+        position: fixed;
+        bottom: 10px;
+        left: 10px;
+        font-family: Helvetica;
+        font-size: 17px;
+        height: auto;
+        width: 15%;
+        margin: 20px;
+        padding: 10px;
+        text-align: center;
         opacity: 0;
+        transition: all 1.0s ease-in-out; 
+        transform: translateY(100%);
+        transition: all 600ms cubic-bezier(0.77, 0, 0.175, 1);
       }
 
       .show-message {
-        background-color: red;
-        opacity: 1;
+        transform: none;
+        opacity: 0.9;
       }
+
+
+
     </style>
     <div class="columns">
       <div class="column-1">
-        <h1 id="popupBox" class="message-box">Save</h1>
+        <h2 id="popupBox" class="message-box">Save</h2>
       </div>
       <div class="card-container column-2">
         <div class="create-user-row">
@@ -147,8 +165,8 @@
       popupMessage(action) {
         let animationTime = 3000;
         let messageBox = this.$.popupBox;
-        messageBox.textContent = action + 'Successful';
-        messageBox.className = 'message-box show-message';
+        messageBox.textContent = action + ' Successful';
+        messageBox.className = 'message-box show-message ' + action;
         window.setTimeout(() => {
           messageBox.className = 'message-box';
         }, animationTime);


### PR DESCRIPTION
## What It Does
Adds style to the popup message and placement of it on the screen.

Also adds a transition animation to have it fade in/up and out/down.

## How To Test

You can adjust the animation speeds and popup ares in the .message-box and .show-message classes.

## Checklist

Under penalty of public shaming, I avow that I:

- [ ] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [ ] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [ ] Updated the docs, if necessary
- [ ] Included the appropriate labels
- [ ] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)

Browsers tested:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer

## Dependencies

- [ ] any other PRs or issues that should be resolved/merged before this is merged
