### PR TITLE
Onboarding Project: Bug Fix - Card styles reset immediately to default after delete

### DIFF
--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -23,12 +23,6 @@
         box-shadow: rgba(0, 0, 0, 0.14902) 0px 1px 1px 0px, rgba(0, 0, 0, 0.09804) 0px 1px 2px 0px;
       }
 
-      .collapse-existing-user {
-        height: 70px;
-        padding: 10px 0px 30px 0px;
-        transition: height .4s ease-out;
-      }
-
       form {
         margin: auto;
         width: 370px;
@@ -128,12 +122,34 @@
         width: 0px;
       }
 
+      .collapse-existing-user {
+        height: 70px;
+        padding: 10px 0px 30px 0px;
+        transition: height .4s ease-out;
+      }
+
+
       .collapse-existing-user>form {
         height: 0px;
         visibility: hidden;
       }
 
       .collapse-existing-user>.id {
+        opacity: 0;
+        visibility: hidden;
+      }
+
+      .collapse-existing-user-default {
+        height: 70px;
+        padding: 10px 0px 30px 0px;
+      }
+
+      .collapse-existing-user-default>form {
+        height: 0px;
+        visibility: hidden;
+      }
+
+      .collapse-existing-user-default>.id {
         opacity: 0;
         visibility: hidden;
       }
@@ -304,6 +320,7 @@
               return {
                 COLLAPSE_NEW: 'default-card collapse-new-user',
                 COLLAPSE_EXISTING: 'default-card collapse-existing-user',
+                COLLAPSE_DEFAULT: 'default-card collapse-existing-user-default',
                 EXPAND_NEW: 'default-card expand-new-user',
                 EXPAND_EXISTING: 'default-card expand-existing-user',
                 RESET_AFTER_DELETE: 'default-card reset-after-delete',
@@ -420,7 +437,7 @@
         database.deleteUser(this.user);
         this.editInProgress(false);
         this.mode = this.modes.DISPLAY;
-        this.userCardClass = this.classes.COLLAPSE_EXISTING;
+        this.userCardClass = this.classes.COLLAPSE_DEFAULT;
         this.toggleEditable();
         this.clearInputFormatWarningMessages();
       }


### PR DESCRIPTION
## What It Does

Fixes the display of a user card after delete.

When the dom-repeat refreshes, it recycles previous information to increase load times. Because of this, any class and animation changes made to a card will persist. So this PR changes the styling of 
 user display cards to being in the default collapsed state, just before they are deleted.

I changed 

`this.userCardClass = this.classes.COLLAPSE_EXISTING;`

to

`this.userCardClass = this.classes.COLLAPSE_DEFAULT;`

```
delete(e) {
        e.preventDefault();
        database.deleteUser(this.user);
        this.editInProgress(false);
        this.mode = this.modes.DISPLAY;
        this.userCardClass = this.classes.COLLAPSE_DEFAULT;
        this.toggleEditable();
        this.clearInputFormatWarningMessages();
      }
```

In the CSS I added a set of `.collapse-existing-user-default` classes set to the collapse position without animation as `.collapse-existing-user` has animations that persist into the next user card.

## How To Test

Create users and delete them, they should appear and disappear as you'd expect. And with no animations on create or delete.

## Checklist

Under penalty of public shaming, I avow that I:

- [ x ] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [ x ] Verified that there are no compiler or linter errors or warnings
- [ x ] Verified the build in production(optimized) mode
- [ x ] Updated the docs, if necessary
- [ x ] Included the appropriate labels
- [ x ] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)

Browsers tested:
- [ x ] Chrome
- [ x ] Firefox
- [ x ] Safari
- ~[ ] Edge~
- ~[ ] Internet Explorer~

## Dependencies

- [ ] any other PRs or issues that should be resolved/merged before this is merged
