### PR TITLE
Fixes unresolved conflict in master

### DIFF
--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -31,7 +31,6 @@
         box-shadow: rgba(0, 0, 0, 0.14902) 0px 1px 1px 0px, rgba(0, 0, 0, 0.09804) 0px 1px 2px 0px;
       }
 
-<<<<<<< HEAD
       .create-user-button:hover>jha-add-person-icon {
         fill: #0070b7;
       }
@@ -42,8 +41,6 @@
         transition: height .4s ease-out;
       }
 
-=======
->>>>>>> master
       form {
         margin: auto;
         width: 370px;


### PR DESCRIPTION
## What It Does

There were a series of merge conflicts in PRs yesterday that I had to resolve. This apparently slipped through. It was just leftover tags that was around this.

```js
.create-user-button:hover>jha-add-person-icon {
        fill: #0070b7;
      }
```
I deleted the tags and tested how the code was functioning.

## How To Test

When you hover over the create user button, it should turn blue.



## Checklist

Under penalty of public shaming, I avow that I:

- [ ] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [ ] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [ ] Updated the docs, if necessary
- [ ] Included the appropriate labels
- [ ] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)

Browsers tested:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer

## Dependencies

- [ ] any other PRs or issues that should be resolved/merged before this is merged
