### PR TITLE
Onboarding Project: Bug Fix – Persistent Collapse User Detail Arrow Icon

### DIFF
--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -31,7 +31,6 @@
         box-shadow: rgba(0, 0, 0, 0.14902) 0px 1px 1px 0px, rgba(0, 0, 0, 0.09804) 0px 1px 2px 0px;
       }
 
-<<<<<<< HEAD
       .create-user-button:hover>jha-add-person-icon {
         fill: #0070b7;
       }
@@ -42,8 +41,6 @@
         transition: height .4s ease-out;
       }
 
-=======
->>>>>>> master
       form {
         margin: auto;
         width: 370px;
@@ -528,6 +525,7 @@
         this.editInProgress(false);
         this.mode = this.modes.DISPLAY;
         this.userCardClass = this.classes.COLLAPSE_DEFAULT;
+        this.toggleUserCardButtonIcon();
         this.toggleEditable();
         this.clearInputFormatWarningMessages();
       }


### PR DESCRIPTION
## What It Does

This fixes #77 

Dom-repeat recycles information from previous dom-repeated items, so changes persist to other dom-repeated items if you delete one of the dom-repeated items. 

I fixed the problem by adding the toggle icon function to the function called when you delete a user.

```js
 delete(e) {
        e.preventDefault();
        database.deleteUser(this.user);
        this.editInProgress(false);
        this.mode = this.modes.DISPLAY;
        this.userCardClass = this.classes.COLLAPSE_DEFAULT;
        **this.toggleUserCardButtonIcon();**
        this.toggleEditable();
        this.clearInputFormatWarningMessages();
      }
```
closes #77 

## How To Test

Create two users (if you don't have any users), expand the top user, delete the top user. The remaining user should display normally. In particular the arrow icon at the bottom of the card should be black and pointing down (ready to expand on click).

## Checklist

Under penalty of public shaming, I avow that I:

- [ ] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [x] Verified the build in production(optimized) mode
- [ ] Updated the docs, if necessary
- [ ] Included the appropriate labels
- [ ] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)

Browsers tested:
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer

## Dependencies

