### PR TITLE
Onboarding Project: Bug Fix – Expanding User Card Requires 2 Clicks After A Delete 

### DIFF
--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -426,7 +426,6 @@
         if (this.user.id) {
           this.toggleEditable();
           this.userCardClass = this.classes.COLLAPSE_EXISTING;
-          // this.toggleUserCardCollapse();
         } else {
           this.resetNewUserForm();
         }
@@ -576,35 +575,25 @@
       }
 
       toggleUserCardCollapse() {
-        let collapsed = this.classes.COLLAPSE_EXISTING;
-        let expanded = this.classes.EXPAND_EXISTING;
-        let afterDelete = this.userCardClass === this.classes.COLLAPSE_DEFAULT;
+        let collapsedClass = this.classes.COLLAPSE_EXISTING;
+        let expandedClass = this.classes.EXPAND_EXISTING;
+        let classAfterDelete = this.classes.COLLAPSE_DEFAULT;
+        let userCardClass = this.userCardClass;
+        let isCollapsed = (userCardClass === classAfterDelete || userCardClass === collapsedClass);
 
-        if (afterDelete) {
-          this.userCardClass = expanded;
-        } else {
-          this.userCardClass = this.userCardClass === collapsed ? expanded : collapsed;
-        }
+        this.userCardClass = isCollapsed ? expandedClass : collapsedClass;
 
         this.toggleUserCardButtonIcon();
       }
 
       toggleUserCardButtonIcon() {
         let button = this.shadowRoot.querySelector('#detailsButton');
-        let buttonIcon;
         let upArrowIcon = '<jha-up-arrow-icon></jha-up-arrow-icon>';
         let dropArrowIcon = '<jha-drop-arrow-icon></jha-drop-arrow-icon>';
-        let afterDelete = this.userCardClass === this.classes.COLLAPSE_DEFAULT;
+        let cardClass = this.userCardClass;
+        let collapsed = (cardClass === this.classes.COLLAPSE_DEFAULT || cardClass === this.classes.COLLAPSE_EXISTING);
 
-        if (afterDelete) {
-          buttonIcon = dropArrowIcon;
-        } else {
-          buttonIcon = (this.userCardClass === this.classes.EXPAND_EXISTING) ? upArrowIcon : dropArrowIcon;
-        }
-
-        if (button) {
-          button.innerHTML = buttonIcon;
-        }
+        button.innerHTML = collapsed ? dropArrowIcon : upArrowIcon;
       }
 
       updateDisableSave() {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -37,7 +37,7 @@
         margin: 0;
         transition: background-color .2s;
       }
-      
+
       .create-user-button:hover>jha-add-person-icon {
         fill: #0070b7;
 
@@ -425,7 +425,8 @@
       initCardState() {
         if (this.user.id) {
           this.toggleEditable();
-          this.toggleUserCardCollapse();
+          this.userCardClass = this.classes.COLLAPSE_EXISTING;
+          // this.toggleUserCardCollapse();
         } else {
           this.resetNewUserForm();
         }
@@ -577,18 +578,29 @@
       toggleUserCardCollapse() {
         let collapsed = this.classes.COLLAPSE_EXISTING;
         let expanded = this.classes.EXPAND_EXISTING;
+        let afterDelete = this.userCardClass === this.classes.COLLAPSE_DEFAULT;
 
-        this.userCardClass = this.userCardClass === collapsed ? expanded : collapsed;
+        if (afterDelete) {
+          this.userCardClass = expanded;
+        } else {
+          this.userCardClass = this.userCardClass === collapsed ? expanded : collapsed;
+        }
 
         this.toggleUserCardButtonIcon();
       }
 
       toggleUserCardButtonIcon() {
         let button = this.shadowRoot.querySelector('#detailsButton');
+        let buttonIcon;
         let upArrowIcon = '<jha-up-arrow-icon></jha-up-arrow-icon>';
         let dropArrowIcon = '<jha-drop-arrow-icon></jha-drop-arrow-icon>';
+        let afterDelete = this.userCardClass === this.classes.COLLAPSE_DEFAULT;
 
-        let buttonIcon = (this.userCardClass === this.classes.EXPAND_EXISTING) ? upArrowIcon : dropArrowIcon;
+        if (afterDelete) {
+          buttonIcon = dropArrowIcon;
+        } else {
+          buttonIcon = (this.userCardClass === this.classes.EXPAND_EXISTING) ? upArrowIcon : dropArrowIcon;
+        }
 
         if (button) {
           button.innerHTML = buttonIcon;


### PR DESCRIPTION
## What It Does

Fixes the bug that made you have to click the expand user details button twice before it would work.

Previous fixes were to the state of the user card and the icons in it. Round one was #75 and round two was PR #82. 

This rounds those changes out by: 

- changing how the card init works (previously it called `toggleUserCardCollapse`)

```js
 if (this.user.id) {
          this.toggleEditable();
          this.userCardClass = this.classes.COLLAPSE_EXISTING;
        }
```

- setting the toggle functions to check for the EXPANDED_DEFAULT state that gets set to a card on delete (and persists to other remaining cards in the dom-repeat template because of information recycling feature of dom-repeat).

```js
 let collapsed = (cardClass === this.classes.COLLAPSE_DEFAULT || cardClass === this.classes.COLLAPSE_EXISTING);

        button.innerHTML = collapsed ? dropArrowIcon : upArrowIcon;
```

## How To Test

- Create two users
- Delete the top user
- Click the arrow to expand the remaining user. It should open in a graceful manner that reminds you of the smell of roses.

- Create and delete multiple users to check no other functionality was accidentally altered.

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [x] Verified the build in production(optimized) mode
- [ ] ~Updated the docs, if necessary~
- [x] Included the appropriate labels
- [x] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)

Browsers tested:
- [x] Chrome
- [x] Firefox NEW ERROR FOUND IN FIREFOX RELATED TO WEBPACK. ISSUE OPENED
- [x] Safari
- [ ] ~Edge~
- [ ] ~Internet Explorer~

## Dependencies

None
