### PR TITLE
Onboarding Project: User Card Spacing Fix.

### DIFF
--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -37,7 +37,7 @@
         margin: 0;
         transition: background-color .2s;
       }
-      
+
       .create-user-button:hover>jha-add-person-icon {
         fill: #0070b7;
 
@@ -66,6 +66,10 @@
 
       .last-name {
         width: 38%;
+      }
+
+      .edit-user-header {
+        margin-bottom: 0px;
       }
 
       .id {
@@ -245,6 +249,9 @@
           <h3>ID:</h3>
           <p class="id">[[user.id]]</p>
         </div>
+      </template>
+      <template is="dom-if" if="[[isEditExisting(mode)]]">
+        <h1 class="edit-user-header">Edit: [[user.last]], [[user.first]]</h1>
       </template>
       <template is="dom-if" if="[[isCreateMode(mode)]]">
         <button id="addUserButton" on-click="toggleNewUserCardDisplay" class="create-user-button">
@@ -503,6 +510,11 @@
         return (this.mode === this.modes.EDIT) && isNewUserCard;
       }
 
+      isEditExisting(currentMode) {
+        let isExistingUser = this.user.id;
+        let existingUserEdit = (currentMode === this.modes.EDIT) && isExistingUser;
+        return existingUserEdit;
+      }
       resetFormState() {
         this.editInProgress(false);
         let isNewUserCard = !this.user.id;

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -52,20 +52,24 @@
         width: 370px;
       }
 
-      form>input {
+      input:not(.name) {
         width: 80%;
         margin-top: 20px;
         font-size: 20px;
         display: inline-block;
       }
 
-      .first-name {
+      .first-name,
+      .last-name {
         width: 38%;
+        margin-top: 20px;
+        font-size: 20px;
+        display: inline-block;
         margin-right: 4%;
       }
 
-      .last-name {
-        width: 38%;
+      .first-name {
+        margin-right: 4%;
       }
 
       .edit-user-header {
@@ -263,11 +267,11 @@
         <template is="dom-if" if="[[isMode(modes.EDIT, mode)]]">
           <label for="firstName"></label>
           <jha-person-icon></jha-person-icon>
-          <input id="firstName" type="text" class="first-name edit" placeholder="First" autocomplete="given-name" value="{{user.first::change}}"
+          <input id="firstName" type="text" class="first-name name" placeholder="First" autocomplete="given-name" value="{{user.first::change}}"
             required>
 
           <label for="lastName"></label>
-          <input id="lastName" type="text" class="last-name edit" placeholder="Last" autocomplete="family-name" value="{{user.last::change}}"
+          <input id="lastName" type="text" class="last-name name" placeholder="Last" autocomplete="family-name" value="{{user.last::change}}"
             required>
           <br>
         </template>
@@ -275,7 +279,7 @@
         <label for="email">
         </label>
         <jha-email-icon></jha-email-icon>
-        <input id="email" type="email" on-blur="formWatcher" class="email edit" placeholder="Email" autocomplete="email" value="{{user.email::change}}"
+        <input id="email" type="email" on-blur="formWatcher" class="email" placeholder="Email" autocomplete="email" value="{{user.email::change}}"
           name="email" required>
         <br>
 
@@ -286,7 +290,7 @@
         <label for="phone">
         </label>
         <jha-phone-icon></jha-phone-icon>
-        <input id="phone" type="tel" on-blur="formWatcher" class="phone edit" placeholder="Phone" autocomplete="tel" value="{{user.phone::change}}"
+        <input id="phone" type="tel" on-blur="formWatcher" class="phone" placeholder="Phone" autocomplete="tel" value="{{user.phone::change}}"
           required>
         <br>
 
@@ -296,7 +300,7 @@
 
         <label for="department"></label>
         <jha-department-icon></jha-department-icon>
-        <input id="department" class="department edit" placeholder="Department" value="{{user.department::change}}" required/>
+        <input id="department" class="department" placeholder="Department" value="{{user.department::change}}" required/>
 
         <!-- bplint-enable no-auto-binding -->
         <div class="submit-button-box">


### PR DESCRIPTION
## What It Does

There were spacing issues in the open edit card, in part because former display of the edit card had a "Edit: First Last" format. 

So I re-added a dom-if template that took care of this. Minor styling to that header solved the spacing issue in the existing user card.

<img width="434" alt="screen shot 2018-08-16 at 3 31 33 pm" src="https://user-images.githubusercontent.com/23724997/44230575-8207fe00-a169-11e8-961f-11be12faae0c.png">

## How To Test

Open an edit on a user. It should display the "Edit: First Last" properly and in a pleasing manner that reminds you of those feels you get standing by a fire on a summer evening.

**Check in Firefox.** 

I am getting some wonky display issues, but I also got issues that @collincahill didn't get in his firefox browser. Please let me know if you are or are not seeing issues there. 

In my Firefox browser, the buttons end up outside of the user card.

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [x] Verified the build in production(optimized) mode
- [x] Updated the docs, if necessary
- [x] Included the appropriate labels
- [x] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)

Browsers tested:
- [x] Chrome
- [x] Firefox POSSIBLE BUG
- [x] Safari
- [ ] ~Edge~
- [ ] ~Internet Explorer~

## Dependencies

None
