### PR TITLE
Bug-Fix: User Name Header Shouldn't Change Till Save

### DIFF
--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -255,7 +255,7 @@
         </div>
       </template>
       <template is="dom-if" if="[[isEditExisting(mode)]]">
-        <h1 class="edit-user-header">Edit: [[user.last]], [[user.first]]</h1>
+        <h1 class="edit-user-header">[[setEditUserHeader(user)]]</h1>
       </template>
       <template is="dom-if" if="[[isCreateMode(mode)]]">
         <button id="addUserButton" on-click="toggleNewUserCardDisplay" class="create-user-button">
@@ -556,6 +556,10 @@
         this.resetFormState();
         this.editInProgress(false);
 
+      }
+
+      setEditUserHeader() {
+        return `Edit: ${this.user.last}, ${this.user.first}`;
       }
 
       toggleMode(e) {


### PR DESCRIPTION
## What It Does

When you would open an edit user card, it properly displayed Edit: Last, First, but because of data binding to the input form, the header would change along with the input form before actually clicking the save button.

I changed data bound data to a data bound function that returned the proper format for the current user. Since it is bound to a change in `user` it only updates on load or save.

```
        <h1 class="edit-user-header">[[setEditUserHeader(user)]]</h1>
```

Fixes #89 

## How To Test

Create a user. Edit that users name, the `Edit: Last, First` should not change to what you've put into the input until you click save.

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [x] Verified the build in production(optimized) mode
- [ ] ~Updated the docs, if necessary~
- [x] Included the appropriate labels
- [x] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)

Browsers tested:
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] ~Edge~
- [ ] ~Internet Explorer~

## Dependencies

None