### PR TITLE
Onboard Project: Bug-Fix Warning messages

### DIFF
--- a/src/user-component/user-component.css
+++ b/src/user-component/user-component.css
@@ -47,3 +47,9 @@ input:read-only {
 input:-webkit-autofill {
   -webkit-box-shadow: 0 0 0px 1000px white inset;
 }
+
+.warning {
+  color: #f44336;
+  font-size: 14px;
+  font-weight: bold;
+}

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -85,12 +85,6 @@
         font-size: 14px;
       }
 
-      .warning {
-        color: red;
-        font-size: 10px;
-        font-weight: bold;
-      }
-
       .submit-button-box {
         margin: auto;
       }
@@ -403,19 +397,15 @@
           },
           openEditMessage: {
             type: String,
-            value: 'Please save other user edits before saving this one.'
+            value: 'You are safe to save this once the other open edits are closed.'
           },
           phoneFormatMessage: {
             type: String,
-            value: 'Please format phone number as (xxx) xxx-xxxx'
+            value: 'Would you mind formatting your number as (xxx) xxx-xxxx?'
           },
           emailFormatMessage: {
             type: String,
-            value: 'Please format email input as xxxx@xxxxx.xxx'
-          },
-          headerMessage: {
-            type: String,
-            value: 'Create New User'
+            value: 'Your email seems a little off. Would you mind formatting it as xxxx@xxxxx.xxx?'
           },
           userToDisplay: {
             type: Object,

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -646,7 +646,7 @@
         if (expandForMessages) {
           this.$.userCard.style.height = 'auto';
         } else {
-          let removeWarningMessageCardResize = ''
+          let removeWarningMessageCardResize = '';
           this.$.userCard.style = removeWarningMessageCardResize;
         }
 

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -529,6 +529,8 @@
       clearInputFormatWarningMessages() {
         this.displayEmailFormatMessage = false;
         this.displayPhoneFormatMessage = false;
+
+        this.resizeCardForWarningMessages(false);
       }
 
       save(e) {
@@ -627,6 +629,27 @@
         if (isNewUser) {
           this.displayOpenEditMessage = this.editOpen;
         }
+
+        if (this.editOpen) {
+          let emailError = this.displayEmailFormatMessage;
+          let phoneError = this.displayPhoneFormatMessage;
+
+          if (emailError || phoneError) {
+            this.resizeCardForWarningMessages(true);
+          }
+
+        }
+
+      }
+
+      resizeCardForWarningMessages(expandForMessages) {
+        if (expandForMessages) {
+          this.$.userCard.style.height = 'auto';
+        } else {
+          let removeWarningMessageCardResize = ''
+          this.$.userCard.style = removeWarningMessageCardResize;
+        }
+
       }
 
       whenEditOpenChanges() {

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -81,7 +81,7 @@
         <div class="user-list-row">
           <template is="dom-if" if="[[noUsersHeaderMessage(users)]]">
             <div class="no-users">
-              <p>There are currently no users in the database. Please create one.</p>
+              <p>There aren't any users in the database at the moment. Would you mind creating one to get started?</p>
             </div>
           </template>
           <template is="dom-repeat" items="[[users]]" as="user">


### PR DESCRIPTION
## What It Does

This changes the color, size, and tone of the warning messages.

Also, it breaks the rules and ALSO fixes card content expanding out of the card when a warning message pops up.

This is a change to reflect JHA's style specifications for [voice](https://jha-design.herokuapp.com/style/voice/) and [color](https://jha-design.herokuapp.com/style/color/). In the meantime I found a bug.

I changed the messages to be more human, and changed them from 'red' to jha's red. 

Closes #92 

## How To Test

- Create two user cards (if you don't already have two). 
- Edit one of the users so that the phone and email are not properly formatted.
- Delete that user.
- The remaining user should collapse, display, and expand normally.

## Notes/Issues 

Discovered a bug that new user entry persists after clicking cancel. 
- [x] Opened issue for bug

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [ ] ~Verified the build in production(optimized) mode~
- [x] Updated the docs, if necessary
- [x] Included the appropriate labels
- [x] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)

Browsers tested:
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] ~Edge~
- [ ] ~Internet Explorer~

## Dependencies

- [ ] #90 (changes made in the same file)
