### PR TITLE
Onboard Project: Bug Fix - Cancel user

### DIFF
--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -573,6 +573,7 @@
         this.userCardClass = this.userCardClass === collapsed ? expanded : collapsed;
 
         this.toggleNewUserCardButtonIcon();
+        this.cancel();
       }
 
       toggleNewUserCardButtonIcon() {
@@ -641,7 +642,6 @@
           if (emailError || phoneError) {
             this.resizeCardForWarningMessages(true);
           }
-
         }
 
       }
@@ -653,7 +653,6 @@
           let removeWarningMessageCardResize = '';
           this.$.userCard.style = removeWarningMessageCardResize;
         }
-
       }
 
       whenEditOpenChanges() {

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -63,12 +63,6 @@
         border-radius: 3px;
         box-shadow: rgba(0, 0, 0, 0.14902) 0px 1px 1px 0px, rgba(0, 0, 0, 0.09804) 0px 1px 2px 0px;
       }
-
-      jha-button {
-        background-color: red;
-        width: 500px;
-        height: 100px;
-      }
     </style>
     <div class="columns">
       <div class="column-1">


### PR DESCRIPTION
## What It Does

Fixes bug that was allowing user input to persist even after cancelling a new user input.

All I had to do was add the existing cancel function into `toggleNewUserCard`

Closes #95 

## How To Test

Start creating a new user. Before saving, click the cancel icon at the top of the card. When you click the add user icon at to expand the card, you should again have an empty input fields in your form.

## Notes/Caveats

I also deleted an old piece of CSS code that was supposed to be deleted in #88 

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [ ] ~Verified the build in production(optimized) mode~
- [ ] ~Updated the docs, if necessary~
- [x] Included the appropriate labels
- [x] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)

Browsers tested:
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] ~Edge~
- [ ] ~Internet Explorer~

## Dependencies

None
