### PR TITLE
Onboarding Project: Added CREATE_MODE

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,35 @@ To create a new user, click the 'Create User' button and fill out the form. User
 
 #### Modes
 
-User component has two mode settings:
+User component has three mode settings:
 
-`<user-component mode=['edit', 'display']><user-component>`
+1. Display: If you pass a `user` object with an `id` property in to the `user-to-display` attribute, then the card will default to a collapsed display mode that only shows the first and last name and the expand for details button.
 
-Changing that mode in the code will cause the state of the card to be that mode on load. If no user is passed into the component it will serve as a 'create new user' card.
+```html
+ <user-component user-to-display="[[userToDisplay]]"></user-component>
+```
+
+```js
+  static get properties() {
+    return {
+
+      // Format of the user object to be passed in
+      userToDisplay: {
+        type: Object,
+        value: {
+          first: "Jane",
+          last: "Doe",
+          id: "827104937",
+          email: "something@gmail.com",
+          phone: "(345) 435-9875"
+        }
+      }
+    }
+  }
+```
+
+2. Edit: Edit is availably in an existing user display card when you click edit.
+3. Create New: If there is not a `user` object passed in with an `id` property, then the card will init as a create new user button that expands into the create new user form when you click it.
 
 #### Disable Functionality
 

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -432,6 +432,7 @@
 
       initCardState() {
         if (this.user.id) {
+          this.mode = this.modes.READ_ONLY;
           this.toggleEditable();
           this.userCardClass = this.classes.COLLAPSE_EXISTING;
         } else {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -531,11 +531,11 @@
 
         let user = Object.assign({}, this.user);
 
-        if (user.id) {
-          database.editUser(user);
-        } else {
+        if (this.isMode(this.modes.CREATE_NEW)) {
           database.saveUser(user);
           this.isVisible = false;
+        } else {
+          database.editUser(user);
         }
 
         this.resetFormState();
@@ -603,7 +603,7 @@
       }
 
       updateDisableSave() {
-        let editOpenAndNewUser = this.editOpen && !this.user.id;
+        let editOpenAndNewUser = this.editOpen && (this.mode === this.modes.CREATE_NEW);
         let emptyFields = !this.fieldsFilled();
         let improperPhoneFormat = !ValidateUtil.checkPhoneInput(this.user.phone);
         let improperEmailFormat = !ValidateUtil.checkEmailInput(this.user.email);

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -244,17 +244,17 @@
 
     <div id="userCard" class$="[[userCardClass]]">
       <header class="card_header">
-        <template is="dom-if" if="[[isMode(modes.DISPLAY, mode)]]">
+        <template is="dom-if" if="[[isMode(modes.READ_ONLY, mode)]]">
           <h1>[[user.last]], [[user.first]]</h1>
           <div class="id" id="id">
             <h3>ID:</h3>
             <p class="id">[[user.id]]</p>
           </div>
         </template>
-        <template is="dom-if" if="[[isEditExisting(mode)]]">
+        <template is="dom-if" if="[[isMode(modes.EDIT_EXISTING, mode)]]">
           <h1 class="edit-user-header">[[setEditUserHeader(user)]]</h1>
         </template>
-        <template is="dom-if" if="[[isCreateMode(mode)]]">
+        <template is="dom-if" if="[[isMode(modes.CREATE_NEW, mode)]]">
           <button id="addUserButton" on-click="toggleNewUserCardDisplay" class="create-user-button">
             <jha-add-person-icon></jha-add-person-icon>
           </button>
@@ -263,7 +263,7 @@
       <div class="card_content">
         <form on-input="formWatcher" autocomplete="on">
           <!-- bplint-disable no-auto-binding -->
-          <template is="dom-if" if="[[isMode(modes.EDIT, mode)]]">
+          <template is="dom-if" if="[[!isMode(modes.READ_ONLY, mode)]]">
             <label for="firstName"></label>
             <jha-person-icon></jha-person-icon>
             <input id="firstName" type="text" class="first-name name" placeholder="First" autocomplete="given-name" value="{{user.first::change}}"
@@ -304,7 +304,7 @@
           <!-- bplint-enable no-auto-binding -->
           <div class="submit-button-box">
 
-            <template is="dom-if" if="[[isMode(modes.EDIT, mode)]]">
+            <template is="dom-if" if="[[!isMode(modes.READ_ONLY, mode)]]">
               <button class="save-button" on-click="save" type="submit" disabled="[[disableSave]]">Save</button>
 
               <template is="dom-if" if="[[user.id]]">
@@ -317,14 +317,14 @@
 
 
             </template>
-            <template is="dom-if" if="[[isMode(modes.DISPLAY, mode)]]">
+            <template is="dom-if" if="[[isMode(modes.READ_ONLY, mode)]]">
               <button on-click="editButtonClicked" type="submit" disabled="[[editOpen]]">Edit</button>
             </template>
           </div>
         </form>
       </div>
       <footer class="card_footer">
-        <template is="dom-if" if="[[isMode(modes.DISPLAY, mode)]]">
+        <template is="dom-if" if="[[isMode(modes.READ_ONLY, mode)]]">
           <div id="detailsButton" on-click="toggleUserCardCollapse" class="expand-details-clickable">
             <jha-drop-arrow-icon></jha-drop-arrow-icon>
           </div>

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -348,9 +348,9 @@
             type: Object,
             value: () => {
               return {
-                DISPLAY: 'display',
-                EDIT: 'edit',
-                CREATE: 'create'
+                READ_ONLY: 'display',
+                EDIT_EXISTING: 'edit',
+                CREATE_NEW: 'create'
               };
             }
           },
@@ -435,6 +435,7 @@
           this.toggleEditable();
           this.userCardClass = this.classes.COLLAPSE_EXISTING;
         } else {
+          this.mode = this.modes.CREATE_NEW;
           this.resetNewUserForm();
         }
 
@@ -470,7 +471,7 @@
         e.preventDefault();
         database.deleteUser(this.user);
         this.editInProgress(false);
-        this.mode = this.modes.DISPLAY;
+        this.mode = this.modes.READ_ONLY;
         this.userCardClass = this.classes.COLLAPSE_DEFAULT;
         this.toggleUserCardButtonIcon();
         this.toggleEditable();
@@ -480,7 +481,7 @@
       editButtonClicked(e) {
         e.preventDefault();
         this.editInProgress(true);
-        this.mode = this.modes.EDIT;
+        this.mode = this.modes.EDIT_EXISTING;
         this.toggleEditable();
       }
 
@@ -506,26 +507,12 @@
         return expectedMode === this.mode;
       }
 
-      isCreateMode() {
-        let isNewUserCard = !this.user.id;
-        return (this.mode === this.modes.EDIT) && isNewUserCard;
-      }
-
-      isEditExisting(currentMode) {
-        let isExistingUser = this.user.id;
-        let existingUserEdit = (currentMode === this.modes.EDIT) && isExistingUser;
-        return existingUserEdit;
-      }
       resetFormState() {
         this.editInProgress(false);
-        let isNewUserCard = !this.user.id;
-        let isUserEditCard = this.user.id;
 
-        if (isUserEditCard) {
+        if (this.isMode(this.modes.EDIT_EXISTING)) {
           this.toggleMode();
-        }
-
-        if (isNewUserCard) {
+        } else {
           this.toggleNewUserCardDisplay();
           this.resetNewUserForm();
         }
@@ -536,7 +523,6 @@
       clearInputFormatWarningMessages() {
         this.displayEmailFormatMessage = false;
         this.displayPhoneFormatMessage = false;
-
         this.resizeCardForWarningMessages(false);
       }
 
@@ -562,14 +548,14 @@
       }
 
       toggleMode(e) {
-        this.mode = this.isMode(this.modes.EDIT) ? this.modes.DISPLAY : this.modes.EDIT;
+        this.mode = this.isMode(this.modes.EDIT_EXISTING) ? this.modes.READ_ONLY : this.modes.EDIT_EXISTING;
         this.toggleEditable();
       }
 
       toggleEditable() {
         this.shadowRoot.querySelectorAll('input')
           .forEach(input => {
-            input.readOnly = this.isMode(this.modes.DISPLAY);
+            input.readOnly = this.isMode(this.modes.READ_ONLY);
           });
       }
 

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -307,7 +307,7 @@
             <template is="dom-if" if="[[!isMode(modes.READ_ONLY, mode)]]">
               <button class="save-button" on-click="save" type="submit" disabled="[[disableSave]]">Save</button>
 
-              <template is="dom-if" if="[[user.id]]">
+              <template is="dom-if" if="[[isMode(modes.EDIT_EXISTING, mode)]]">
                 <button on-click="delete" type="submit" formnovalidate>Delete</button>
               </template>
 
@@ -613,7 +613,7 @@
       }
 
       updateWarningMessages() {
-        let isNewUser = !this.user.id;
+        let isNewUserCard = this.isMode(this.modes.CREATE_NEW);
         let emailInProgress = this.user.email;
         let phoneInProgress = this.user.phone;
 
@@ -625,7 +625,7 @@
           this.displayPhoneFormatMessage = !ValidateUtil.checkPhoneInput(this.user.phone);
         }
 
-        if (isNewUser) {
+        if (isNewUserCard) {
           this.displayOpenEditMessage = this.editOpen;
         }
 

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -79,7 +79,7 @@
             </div>
           </template>
           <template is="dom-repeat" items="[[users]]" as="user">
-            <user-component edit-open="[[editInProgress]]" mode="display" user-to-display="[[user]]"></user-component>
+            <user-component edit-open="[[editInProgress]]" user-to-display="[[user]]"></user-component>
           </template>
         </div>
       </div>

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -70,7 +70,7 @@
       </div>
       <div class="card-container column-2">
         <div class="create-user-row">
-          <user-component class="new-user-card" edit-open="[[editInProgress]]" mode="edit"></user-component>
+          <user-component class="new-user-card" edit-open="[[editInProgress]]"></user-component>
         </div>
         <div class="user-list-row">
           <template is="dom-if" if="[[noUsersHeaderMessage(users)]]">


### PR DESCRIPTION
## What It Does

This adds `CREATE_MODE` to the user-component and refactors dom-ifs and other functions to use CREATE_MODE rather than various `&&` or `||` statements to figure out the state.

There have for a long time been three states of user-component:

- Create New
- Display Existing
- Edit Existing

But prior to this PR the Create New state was typically found by using something like `let isNewUserCard = !this.user.id` as user.id was only a part of existing users.

To implement:

- I added CREATE_NEW to my modes property.
- I moved the setting of the initial card state inside the user component. The initial state is now set by whether or not a user is passed to the user-component. If it is, then the card starts collapsed in display mode. If not, then the card starts as a collapsed create new user card.
- I refactored any instance where CREATE_NEW simplified readability or complexity.

## How To Test

- Create Cards
- Delete Cards
- Open edits on existing users and save

All previous functionality, messages, and disable buttons should work as they did previously as this commit is not supposed to change any functionality or style.

## Notes/Caveats

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [x] Updated the docs, if necessary
- [x] Included the appropriate labels
- [x] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)

Browsers tested:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer

## Dependencies

- [ ] #97 
