### PR TITLE
Onboarding Project: Bug Fix - Card's In User List Maintain State After New User Save or Delete

### DIFF
--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -554,10 +554,18 @@
       }
 
       
+      toggleIsExpanded() {
+        let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
+        let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
+        let isExpanded = this.isClass(animatedCollapsed) || this.isClass(defaultCollapsed);
 
-        let isCollapsed = (this.isClass(this.classes.COLLAPSE_DEFAULT) || this.isClass(this.classes.COLLAPSE_EXISTING));
+        this.dispatchEvent(new CustomEvent('cardDetailDisplayToggled', {
+          bubbles: true,
+          composed: true,
+          detail: { id: this.user.id, expanded: isExpanded }
+        }));
 
-        button.innerHTML = isCollapsed ? dropArrowIcon : upArrowIcon;
+        this.setUserCardDisplayState();
       }
 
       editButtonClicked(e) {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -334,7 +334,7 @@
       </div>
       <footer class="card_footer">
         <template is="dom-if" if="[[isMode(modes.DISPLAY, mode)]]">
-          <div id="detailsButton" on-click="toggleUserCardCollapse" class="expand-details-clickable">
+          <div id="detailsButton" on-click="toggleIsExpanded" class="expand-details-clickable">
             <template is="dom-if" if="[[isClass(classes.EXPAND_EXISTING, userCardClass)]]">
               <jha-up-arrow-icon></jha-up-arrow-icon>
             </template>
@@ -375,7 +375,8 @@
               return {
                 COLLAPSE_NEW: 'default-card collapse-new-user',
                 COLLAPSE_EXISTING: 'default-card collapse-existing-user',
-                COLLAPSE_DEFAULT: 'default-card collapse-existing-user-default',
+                COLLAPSE_EXISTING_DEFAULT: 'default-card collapse-existing-user-default',
+                EXPAND_EXISTING_DEFAULT: 'default-card expand-existing-user-default',
                 EXPAND_NEW: 'default-card expand-new-user',
                 EXPAND_EXISTING: 'default-card expand-existing-user',
               };
@@ -423,6 +424,10 @@
           emailFormatMessage: {
             type: String,
             value: 'Your email seems a little off. Would you mind formatting it as xxxx@xxxxx.xxx?'
+          },
+          isExpanded: {
+            type: Boolean,
+            observer: 'setUserCardDisplayState'
           },
           // passed in from parent of user-component
           userToDisplay: {
@@ -543,17 +548,35 @@
         return fieldsFilled;
       }
 
-      toggleUserCardCollapse() {
-        let collapsed = this.classes.COLLAPSE_EXISTING;
-        let expanded = this.classes.EXPAND_EXISTING;
-        let resetAfterDelete = this.classes.COLLAPSE_DEFAULT;
+      setUserCardDisplayState(event) {
+        let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
+        let animatedExpanded = this.classes.EXPAND_EXISTING;
+        let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
+        let defaultExpanded = this.classes.EXPAND_EXISTING_DEFAULT;
 
-        let isCollapsed = (this.isClass(resetAfterDelete) || this.isClass(collapsed));
+        let isCollapsed = (this.isClass(animatedCollapsed) || this.isClass(defaultCollapsed));
 
+        let isListUpdate = typeof event === 'boolean';
 
+        if (isListUpdate) {
+          this.setListUpdateCardState(isCollapsed)
+        } else {
+          this.setClickEventCardState(isCollapsed);
+        }
       }
 
-      
+      setListUpdateCardState(isCollapsed) {
+        let expanded = this.classes.EXPAND_EXISTING_DEFAULT;
+        let collapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
+        this.userCardClass = this.isExpanded ? expanded : collapsed;
+      }
+
+      setClickEventCardState(isCollapsed) {
+        let collapsed = this.classes.COLLAPSE_EXISTING;
+        let expanded = this.classes.EXPAND_EXISTING;
+        this.userCardClass = isCollapsed ? expanded : collapsed;
+      }
+
       toggleIsExpanded() {
         let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
         let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -615,17 +615,6 @@
         }
       }
 
-      toggleNewUserIcon() {
-        let button = this.shadowRoot.querySelector('#createUserButton');
-        let expanded = this.classes.EXPAND_NEW;
-
-        let cancelIcon = '<jha-cancel-icon></jha-cancel-icon>';
-        let addPersonIcon = '<jha-add-person-icon></jha-add-person-icon>';
-
-        let buttonIcon = this.isClass(expanded) ? cancelIcon : addPersonIcon;
-        button.innerHTML = buttonIcon;
-      }
-
       resetNewUserForm() {
         this.shadowRoot.querySelector('form').reset();
         this.clearFormatWarningMessages();

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -207,6 +207,26 @@
         visibility: hidden;
       }
 
+      .expand-existing-user-default {
+        height: 370px;
+        padding: 10px 0px 30px 0px;
+      }
+
+      .expand-existing-user-default>.card_content>form {
+        height: auto;
+        visibility: visible;
+      }
+
+      .expand-existing-user-default>.card_header>.user-id {
+        opacity: 1;
+        visibility: visible;
+      }
+
+      .expand-existing-user-default>.card_footer>.expand-details-clickable {
+        background-color: #0070b7;
+        cursor: pointer;
+      }
+
       @keyframes fade-in {
         0% {
           opacity: 0;
@@ -484,7 +504,6 @@
         Database.deleteUser(this.user);
         this.editInProgress(false);
         this.mode = this.modes.DISPLAY;
-        this.userCardClass = this.classes.COLLAPSE_DEFAULT;
         this.toggleEditableInputs();
         this.clearFormatWarningMessages();
       }

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -480,7 +480,6 @@
         this.editInProgress(false);
         this.mode = this.modes.DISPLAY;
         this.userCardClass = this.classes.COLLAPSE_DEFAULT;
-        this.toggleUserCardButtonIcon();
         this.toggleEditableInputs();
         this.clearFormatWarningMessages();
       }
@@ -551,15 +550,10 @@
 
         let isCollapsed = (this.isClass(resetAfterDelete) || this.isClass(collapsed));
 
-        this.userCardClass = isCollapsed ? expanded : collapsed;
 
-        this.toggleUserCardButtonIcon();
       }
 
-      toggleUserCardButtonIcon() {
-        let button = this.shadowRoot.querySelector('#detailsButton');
-        let upArrowIcon = '<jha-up-arrow-icon></jha-up-arrow-icon>';
-        let dropArrowIcon = '<jha-drop-arrow-icon></jha-drop-arrow-icon>';
+      
 
         let isCollapsed = (this.isClass(this.classes.COLLAPSE_DEFAULT) || this.isClass(this.classes.COLLAPSE_EXISTING));
 

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -355,10 +355,10 @@
       <footer class="card_footer">
         <template is="dom-if" if="[[isMode(modes.DISPLAY, mode)]]">
           <div id="detailsButton" on-click="toggleIsExpanded" class="expand-details-clickable">
-            <template is="dom-if" if="[[isClass(classes.EXPAND_EXISTING, userCardClass)]]">
+            <template is="dom-if" if="[[detailsExpanded]]">
               <jha-up-arrow-icon></jha-up-arrow-icon>
             </template>
-            <template is="dom-if" if="[[isClass(classes.COLLAPSE_EXISTING, userCardClass)]]">
+            <template is="dom-if" if="[[!detailsExpanded]]">
               <jha-drop-arrow-icon></jha-drop-arrow-icon>
             </template>
 
@@ -447,7 +447,7 @@
           },
           isExpanded: {
             type: Boolean,
-            observer: 'setUserCardDisplayState'
+            observer: 'setUserDetailsDisplay'
           },
           // passed in from parent of user-component
           userToDisplay: {
@@ -567,7 +567,7 @@
         return fieldsFilled;
       }
 
-      setUserCardDisplayState(event) {
+      setUserDetailsDisplay(event) {
         let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
         let animatedExpanded = this.classes.EXPAND_EXISTING;
         let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
@@ -578,22 +578,26 @@
         let isListUpdate = typeof event === 'boolean';
 
         if (isListUpdate) {
-          this.setListUpdateCardState(isCollapsed)
+          this.setDetailsOnListUpdate(isCollapsed);
         } else {
-          this.setClickEventCardState(isCollapsed);
+          this.setDetailsOnButtonClick(isCollapsed);
         }
       }
 
-      setListUpdateCardState(isCollapsed) {
+      setDetailsOnListUpdate(isCollapsed) {
         let expanded = this.classes.EXPAND_EXISTING_DEFAULT;
         let collapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
+
         this.userCardClass = this.isExpanded ? expanded : collapsed;
+        this.detailsExpanded = this.isExpanded;
       }
 
-      setClickEventCardState(isCollapsed) {
+      setDetailsOnButtonClick(isCollapsed) {
         let collapsed = this.classes.COLLAPSE_EXISTING;
         let expanded = this.classes.EXPAND_EXISTING;
+
         this.userCardClass = isCollapsed ? expanded : collapsed;
+        this.detailsExpanded = !this.detailsExpanded;
       }
 
       toggleIsExpanded() {
@@ -607,7 +611,7 @@
           detail: { id: this.user.id, expanded: isExpanded }
         }));
 
-        this.setUserCardDisplayState();
+        this.setUserDetailsDisplay();
       }
 
       editButtonClicked(e) {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -354,7 +354,7 @@
       </div>
       <footer class="card_footer">
         <template is="dom-if" if="[[isMode(modes.DISPLAY, mode)]]">
-          <div id="detailsButton" on-click="toggleIsExpanded" class="expand-details-clickable">
+          <div id="detailsButton" on-click="toggleDetailsVisibility" class="expand-details-clickable">
             <template is="dom-if" if="[[detailsExpanded]]">
               <jha-up-arrow-icon></jha-up-arrow-icon>
             </template>
@@ -567,6 +567,23 @@
         return fieldsFilled;
       }
 
+      toggleDetailsVisibility() {
+        this.saveCardState();
+        this.setUserDetailsDisplay();
+      }
+
+      saveCardState() {
+        let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
+        let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
+        let isExpanded = this.isClass(animatedCollapsed) || this.isClass(defaultCollapsed);
+
+        this.dispatchEvent(new CustomEvent('cardDetailDisplayToggled', {
+          bubbles: true,
+          composed: true,
+          detail: { id: this.user.id, expanded: isExpanded }
+        }));
+      }
+
       setUserDetailsDisplay(event) {
         let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
         let animatedExpanded = this.classes.EXPAND_EXISTING;
@@ -598,20 +615,6 @@
 
         this.userCardClass = isCollapsed ? expanded : collapsed;
         this.detailsExpanded = !this.detailsExpanded;
-      }
-
-      toggleIsExpanded() {
-        let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
-        let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
-        let isExpanded = this.isClass(animatedCollapsed) || this.isClass(defaultCollapsed);
-
-        this.dispatchEvent(new CustomEvent('cardDetailDisplayToggled', {
-          bubbles: true,
-          composed: true,
-          detail: { id: this.user.id, expanded: isExpanded }
-        }));
-
-        this.setUserDetailsDisplay();
       }
 
       editButtonClicked(e) {

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -95,6 +95,10 @@
             type: Boolean,
             value: false
           },
+          expandedCardIds: {
+            type: Array,
+            value: []
+          },
           users: {
             type: Array,
             value: () => Database.getUsers()
@@ -117,6 +121,24 @@
           this.editInProgress = e.detail;
         });
 
+        document.addEventListener('cardDetailDisplayToggled', (e) => {
+          const id = e.detail.id
+          let expanded = e.detail.expanded;
+          return expanded ? this.addIdToExpanded(id) : this.removeIdFromExpanded(id);
+        });
+
+      }
+
+      addIdToExpanded(id) {
+        this.expandedCardIds.splice(0, 0, id);
+      }
+
+      removeIdFromExpanded(id) {
+        // console.log('b');
+        // let expandedIds = this.expandedCardIds;
+        // expandedIds.forEach(expandedId => {
+
+        // });
       }
 
       disconnectedCallback() {

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -74,7 +74,7 @@
             </div>
           </template>
           <template is="dom-repeat" items="[[users]]" as="user">
-            <user-component edit-open="[[editInProgress]]" user-to-display="[[user]]"></user-component>
+            <user-component edit-open="[[editInProgress]]" is-expanded="[[setExpanded(user.id, users)]]" user-to-display="[[user]]"></user-component>
           </template>
         </div>
       </div>
@@ -160,6 +160,17 @@
         window.setTimeout(() => {
           messageBox.className = 'message-box';
         }, animationTime);
+      }
+
+      setExpanded(userId) {
+        let isExpanded = false;
+        this.expandedCardIds.forEach(id => {
+          if (id === userId) {
+            isExpanded = true;
+          }
+        });
+
+        return isExpanded;
       }
     }
 


### PR DESCRIPTION
## What It Does

This Fixes #101 

Because of dom-repeat recycling, if you had expanded the details of the user (let's say his name is Kip), and then you saved a new user (LaFawnduh), LaFawnduh would be displayed with details expanded, whereas Kip would now be collapsed.

To fix this problem:

- `EXPANDED_DEFAULT` was created to put a card into the expanded state without an animation.
- If a card is expanded, an event is sent to user-list that tells user-list whether a card has been expanded or collapsed in order to add (or remove) its id from a list of expanded cards. 
- Whenever new users are brought in from the database, `setExpanded` sets a boolean on each user-component's `is-expanded` attribute as to whether or not it starts out as expanded or collapsed.
- `isExpanded` property was added to user-component and has an observer that fires a function that sets the state of the card.

## How To Test

Any state of expanded or collapsed cards will persist on any new save, edit save, or card delete.

## Notes/Caveats

Are there remaining issues or things this PR hasn't solved yet? Are there long-term implications?

## Checklist

Under penalty of public shaming, I avow that I:

- [ ] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [ ] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [ ] Updated the docs, if necessary
- [ ] Included the appropriate labels
- [ ] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)

Browsers tested:
- [ ] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer

## Dependencies

- [ ] none
