### PR TITLE
Onboarding Project: Bug Fix - Toast Sizing Causes Text To Overflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,11 +66,19 @@ User component has three mode settings:
 2. Edit: Edit is availably in an existing user display card when you click edit.
 3. Create New: If there is not a `user` object passed in with an `id` property, then the card will init as a create new user button that expands into the create new user form when you click it.
 
-#### Disable Functionality
+#### Disable Functionality: edit-open attribute
 
 When an edit button is clicked in a user-component, that user-component dispatches an event received by user-list to let other components know that there is an open edit. The user component uses this boolean to enable/disable save and edit buttons when another edit is open.
 
 `<user-component edit-open="[true,false]"><user-component>`
+
+#### Persistant User Card Display: is-expanded attribute
+
+Because of polymer's dom-repeat information recycling, class changes will persist on a certain index in the user list. So if you've displayed the details on the second user in the list, when you create a new user, it will continue to show the details of the second user in the list (even if the user you opened up details for is now in the third slot).
+
+Because of the dom-recycling feature of Polymer, the display state of each component is checked and its state is set using its id.
+
+`<user-component is-expanded="[[isExpanded(user.id, users)]]" is-open="[true,false]"><user-component>`
 
 ### NPM Scripts
 

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -615,9 +615,11 @@
         this.setDetailsArrowIcon();
       }
 
-      setDetailsArrowIcon() {
+      setDetailsArrowDirection() {
+        let animatedCollapse = this.isClass(this.classes.ANIMATE_COLLAPSE_USER);
+        let immediateCollapse = this.isClass(this.classes.IMMEDIATELY_COLLAPSE_USER);
 
-        this.detailsArrowIconDown = (this.classes.ANIMATE_COLLAPSE_USER || this.classes.IMMEDIATELY_COLLAPSE_USER);
+        this.detailsArrowIconDown = animatedCollapse || immediateCollapse;
       }
 
       editButtonClicked(e) {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -571,9 +571,10 @@
       }
 
       saveCardState() {
-        let animatedCollapsed = this.classes.ANIMATE_COLLAPSE_USER;
-        let defaultCollapsed = this.classes.IMMEDIATELY_COLLAPSE_USER;
-        let isExpanded = this.isClass(animatedCollapsed) || this.isClass(defaultCollapsed);
+        let immediateCollapse = this.classes.IMMEDIATELY_COLLAPSE_USER;
+        let animatedCollapse = this.classes.ANIMATE_COLLAPSE_USER;
+
+        let isExpanded = this.isClass(immediateCollapse) || this.isClass(animatedCollapse);
 
         this.dispatchEvent(new CustomEvent('cardDetailDisplayChanged', {
           bubbles: true,
@@ -607,7 +608,7 @@
         let animatedCollapse = this.classes.ANIMATE_COLLAPSE_USER;
         let animatedExpand = this.classes.ANIMATE_EXPAND_USER;
 
-        let isUserCurrentlyCollapsed = (this.isClass(animatedCollapsed) || this.isClass(immediateCollapse));
+        let isUserCurrentlyCollapsed = (this.isClass(animatedCollapse) || this.isClass(immediateCollapse));
 
         this.userCardClass = isUserCurrentlyCollapsed ? animatedExpand : animatedCollapse;
 

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -554,10 +554,18 @@
       }
 
       
+      toggleIsExpanded() {
+        let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
+        let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
+        let isExpanded = this.isClass(animatedCollapsed) || this.isClass(defaultCollapsed);
 
-        let isCollapsed = (this.isClass(this.classes.COLLAPSE_DEFAULT) || this.isClass(this.classes.COLLAPSE_EXISTING));
+        this.dispatchEvent(new CustomEvent('cardDetailDisplayToggled', {
+          bubbles: true,
+          composed: true,
+          detail: { id: this.user.id, expanded: isExpanded }
+        }));
 
-        button.innerHTML = isCollapsed ? dropArrowIcon : upArrowIcon;
+        this.setUserCardDisplayState();
       }
 
       editButtonClicked(e) {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -584,9 +584,9 @@
       }
 
       setUserDetailsDisplay(event) {
-        let isListUpdate = (typeof event === 'boolean');
+        let eventIsListUpdate = (typeof event === 'boolean');
 
-        if (isListUpdate) {
+        if (eventIsListUpdate) {
           this.setDisplayOnListUpdate();
         } else {
           this.setDisplayOnButtonClick();
@@ -600,7 +600,7 @@
         let wasExpandedBeforeUpdate = this.isExpanded;
 
         this.userCardClass = wasExpandedBeforeUpdate ? expandImmediately : collapseImmediately;
-        this.setDetailsArrowIcon();
+        this.setDetailsArrowDirection();
       }
 
       setDisplayOnButtonClick() {
@@ -612,7 +612,7 @@
 
         this.userCardClass = isUserCurrentlyCollapsed ? animatedExpand : animatedCollapse;
 
-        this.setDetailsArrowIcon();
+        this.setDetailsArrowDirection();
       }
 
       setDetailsArrowDirection() {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -334,7 +334,7 @@
       </div>
       <footer class="card_footer">
         <template is="dom-if" if="[[isMode(modes.DISPLAY, mode)]]">
-          <div id="detailsButton" on-click="toggleUserCardCollapse" class="expand-details-clickable">
+          <div id="detailsButton" on-click="toggleIsExpanded" class="expand-details-clickable">
             <template is="dom-if" if="[[isClass(classes.EXPAND_EXISTING, userCardClass)]]">
               <jha-up-arrow-icon></jha-up-arrow-icon>
             </template>
@@ -375,7 +375,8 @@
               return {
                 COLLAPSE_NEW: 'default-card collapse-new-user',
                 COLLAPSE_EXISTING: 'default-card collapse-existing-user',
-                COLLAPSE_DEFAULT: 'default-card collapse-existing-user-default',
+                COLLAPSE_EXISTING_DEFAULT: 'default-card collapse-existing-user-default',
+                EXPAND_EXISTING_DEFAULT: 'default-card expand-existing-user-default',
                 EXPAND_NEW: 'default-card expand-new-user',
                 EXPAND_EXISTING: 'default-card expand-existing-user',
               };
@@ -423,6 +424,10 @@
           emailFormatMessage: {
             type: String,
             value: 'Your email seems a little off. Would you mind formatting it as xxxx@xxxxx.xxx?'
+          },
+          isExpanded: {
+            type: Boolean,
+            observer: 'setUserCardDisplayState'
           },
           // passed in from parent of user-component
           userToDisplay: {
@@ -543,17 +548,35 @@
         return fieldsFilled;
       }
 
-      toggleUserCardCollapse() {
-        let collapsed = this.classes.COLLAPSE_EXISTING;
-        let expanded = this.classes.EXPAND_EXISTING;
-        let resetAfterDelete = this.classes.COLLAPSE_DEFAULT;
+      setUserCardDisplayState(event) {
+        let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
+        let animatedExpanded = this.classes.EXPAND_EXISTING;
+        let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
+        let defaultExpanded = this.classes.EXPAND_EXISTING_DEFAULT;
 
-        let isCollapsed = (this.isClass(resetAfterDelete) || this.isClass(collapsed));
+        let isCollapsed = (this.isClass(animatedCollapsed) || this.isClass(defaultCollapsed));
 
+        let isListUpdate = typeof event === 'boolean';
 
+        if (isListUpdate) {
+          this.setListUpdateCardState(isCollapsed)
+        } else {
+          this.setClickEventCardState(isCollapsed);
+        }
       }
 
-      
+      setListUpdateCardState(isCollapsed) {
+        let expanded = this.classes.EXPAND_EXISTING_DEFAULT;
+        let collapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
+        this.userCardClass = this.isExpanded ? expanded : collapsed;
+      }
+
+      setClickEventCardState(isCollapsed) {
+        let collapsed = this.classes.COLLAPSE_EXISTING;
+        let expanded = this.classes.EXPAND_EXISTING;
+        this.userCardClass = isCollapsed ? expanded : collapsed;
+      }
+
       toggleIsExpanded() {
         let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
         let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -615,17 +615,6 @@
         }
       }
 
-      toggleNewUserIcon() {
-        let button = this.shadowRoot.querySelector('#createUserButton');
-        let expanded = this.classes.EXPAND_NEW;
-
-        let cancelIcon = '<jha-cancel-icon></jha-cancel-icon>';
-        let addPersonIcon = '<jha-add-person-icon></jha-add-person-icon>';
-
-        let buttonIcon = this.isClass(expanded) ? cancelIcon : addPersonIcon;
-        button.innerHTML = buttonIcon;
-      }
-
       resetNewUserForm() {
         this.shadowRoot.querySelector('form').reset();
         this.clearFormatWarningMessages();

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -207,6 +207,26 @@
         visibility: hidden;
       }
 
+      .expand-existing-user-default {
+        height: 370px;
+        padding: 10px 0px 30px 0px;
+      }
+
+      .expand-existing-user-default>.card_content>form {
+        height: auto;
+        visibility: visible;
+      }
+
+      .expand-existing-user-default>.card_header>.user-id {
+        opacity: 1;
+        visibility: visible;
+      }
+
+      .expand-existing-user-default>.card_footer>.expand-details-clickable {
+        background-color: #0070b7;
+        cursor: pointer;
+      }
+
       @keyframes fade-in {
         0% {
           opacity: 0;
@@ -484,7 +504,6 @@
         Database.deleteUser(this.user);
         this.editInProgress(false);
         this.mode = this.modes.DISPLAY;
-        this.userCardClass = this.classes.COLLAPSE_DEFAULT;
         this.toggleEditableInputs();
         this.clearFormatWarningMessages();
       }

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -583,33 +583,33 @@
       }
 
       setUserDetailsDisplay(event) {
-        let animatedCollapsed = this.classes.ANIMATE_COLLAPSE_USER;
-        let defaultCollapsed = this.classes.IMMEDIATELY_COLLAPSE_USER;
-
-        let isCollapsed = (this.isClass(animatedCollapsed) || this.isClass(defaultCollapsed));
         let isListUpdate = (typeof event === 'boolean');
 
         if (isListUpdate) {
-          this.setDisplayOnListUpdate(isCollapsed);
+          this.setDisplayOnListUpdate();
         } else {
-          this.setDisplayOnButtonClick(isCollapsed);
+          this.setDisplayOnButtonClick();
         }
       }
 
-      setDisplayOnListUpdate(isCollapsed) {
-        let expanded = this.classes.IMMEDIATELY_EXPAND_USER;
-        let collapsed = this.classes.IMMEDIATELY_COLLAPSE_USER;
+      setDisplayOnListUpdate() {
+        let expandImmediately = this.classes.IMMEDIATELY_EXPAND_USER;
+        let collapseImmediately = this.classes.IMMEDIATELY_COLLAPSE_USER;
 
-        this.userCardClass = this.isExpanded ? expanded : collapsed;
+        let wasExpandedBeforeUpdate = this.isExpanded;
 
+        this.userCardClass = wasExpandedBeforeUpdate ? expandImmediately : collapseImmediately;
         this.setDetailsArrowIcon();
       }
 
-      setDisplayOnButtonClick(isCollapsed) {
-        let collapsed = this.classes.ANIMATE_COLLAPSE_USER;
-        let expanded = this.classes.ANIMATE_EXPAND_USER;
+      setDisplayOnButtonClick() {
+        let immediateCollapse = this.classes.IMMEDIATELY_COLLAPSE_USER;
+        let animatedCollapse = this.classes.ANIMATE_COLLAPSE_USER;
+        let animatedExpand = this.classes.ANIMATE_EXPAND_USER;
 
-        this.userCardClass = isCollapsed ? expanded : collapsed;
+        let isUserCurrentlyCollapsed = (this.isClass(animatedCollapsed) || this.isClass(immediateCollapse));
+
+        this.userCardClass = isUserCurrentlyCollapsed ? animatedExpand : animatedCollapse;
 
         this.setDetailsArrowIcon();
       }

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -480,7 +480,6 @@
         this.editInProgress(false);
         this.mode = this.modes.DISPLAY;
         this.userCardClass = this.classes.COLLAPSE_DEFAULT;
-        this.toggleUserCardButtonIcon();
         this.toggleEditableInputs();
         this.clearFormatWarningMessages();
       }
@@ -551,15 +550,10 @@
 
         let isCollapsed = (this.isClass(resetAfterDelete) || this.isClass(collapsed));
 
-        this.userCardClass = isCollapsed ? expanded : collapsed;
 
-        this.toggleUserCardButtonIcon();
       }
 
-      toggleUserCardButtonIcon() {
-        let button = this.shadowRoot.querySelector('#detailsButton');
-        let upArrowIcon = '<jha-up-arrow-icon></jha-up-arrow-icon>';
-        let dropArrowIcon = '<jha-drop-arrow-icon></jha-drop-arrow-icon>';
+      
 
         let isCollapsed = (this.isClass(this.classes.COLLAPSE_DEFAULT) || this.isClass(this.classes.COLLAPSE_EXISTING));
 

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -192,37 +192,37 @@
 
       /* Existing User Reset After User Is Deleted because of Dom-Repeat Class Recycling. */
 
-      .collapse-existing-user-default {
+      .immediately-collapse-existing-user {
         height: 70px;
         padding: 10px 0px 30px 0px;
       }
 
-      .collapse-existing-user-default>.card_content>form {
+      .immediately-collapse-existing-user>.card_content>form {
         height: 0px;
         visibility: hidden;
       }
 
-      .collapse-existing-user-default>.card_header>.user-id {
+      .immediately-collapse-existing-user>.card_header>.user-id {
         opacity: 0;
         visibility: hidden;
       }
 
-      .expand-existing-user-default {
+      .immediately-expand-existing-user {
         height: 370px;
         padding: 10px 0px 30px 0px;
       }
 
-      .expand-existing-user-default>.card_content>form {
+      .immediately-expand-existing-user>.card_content>form {
         height: auto;
         visibility: visible;
       }
 
-      .expand-existing-user-default>.card_header>.user-id {
+      .immediately-expand-existing-user>.card_header>.user-id {
         opacity: 1;
         visibility: visible;
       }
 
-      .expand-existing-user-default>.card_footer>.expand-details-clickable {
+      .immediately-expand-existing-user>.card_footer>.expand-details-clickable {
         background-color: #0070b7;
         cursor: pointer;
       }
@@ -394,8 +394,8 @@
               return {
                 COLLAPSE_NEW: 'default-card collapse-new-user',
                 ANIMATE_COLLAPSE_USER: 'default-card collapse-existing-user',
-                IMMEDIATELY_COLLAPSE_USER: 'default-card collapse-existing-user-default',
-                IMMEDIATELY_EXPAND_USER: 'default-card expand-existing-user-default',
+                IMMEDIATELY_COLLAPSE_USER: 'default-card immediately-collapse-existing-user',
+                IMMEDIATELY_EXPAND_USER: 'default-card immediately-expand-existing-user',
                 EXPAND_NEW: 'default-card expand-new-user',
                 ANIMATE_EXPAND_USER: 'default-card expand-existing-user',
               };

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -566,20 +566,20 @@
       }
 
       toggleDetailsVisibility() {
-        this.saveCardState();
         this.setUserDetailsDisplay();
+        this.saveCardState();
       }
 
       saveCardState() {
-        let immediateCollapse = this.classes.IMMEDIATELY_COLLAPSE_USER;
-        let animatedCollapse = this.classes.ANIMATE_COLLAPSE_USER;
+        let immediatelyExpand = this.classes.IMMEDIATELY_EXPAND_USER;
+        let animateExpand = this.classes.ANIMATE_EXPAND_USER;
 
-        let isExpanded = this.isClass(immediateCollapse) || this.isClass(animatedCollapse);
+        let userCardIsExpanded = this.isClass(immediatelyExpand) || this.isClass(animateExpand);
 
         this.dispatchEvent(new CustomEvent('cardDetailDisplayChanged', {
           bubbles: true,
           composed: true,
-          detail: { id: this.user.id, expanded: isExpanded }
+          detail: { id: this.user.id, expanded: userCardIsExpanded }
         }));
       }
 

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -424,13 +424,16 @@
             observer: 'onEditOpenChanged'
           },
           displayOpenEditMessage: {
-            type: Boolean,
+            type: Boolean
           },
           displayPhoneWarning: {
-            type: Boolean,
+            type: Boolean
           },
           displayEmailWarning: {
-            type: Boolean,
+            type: Boolean
+          },
+          detailsArrowIconDown: {
+            type: Boolean
           },
           openEditMessage: {
             type: String,

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -223,7 +223,8 @@
       }
 
       .expand-existing-user-default>.card_footer>.expand-details-clickable {
-        background-color: #0070b7;
+        background-color: red;
+        /* background-color: #0070b7; */
         cursor: pointer;
       }
 
@@ -472,7 +473,6 @@
         if (isExistingUser) {
           this.mode = this.modes.DISPLAY;
           this.toggleEditableInputs();
-          this.userCardClass = this.classes.COLLAPSE_EXISTING;
         } else {
           this.mode = this.modes.CREATE_NEW;
         }
@@ -586,9 +586,7 @@
 
       setUserDetailsDisplay(event) {
         let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
-        let animatedExpanded = this.classes.EXPAND_EXISTING;
         let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
-        let defaultExpanded = this.classes.EXPAND_EXISTING_DEFAULT;
 
         let isCollapsed = (this.isClass(animatedCollapsed) || this.isClass(defaultCollapsed));
 
@@ -607,6 +605,9 @@
 
         this.userCardClass = this.isExpanded ? expanded : collapsed;
         this.detailsExpanded = this.isExpanded;
+
+        console.log(this.user.first, this.userCardClass);
+
       }
 
       setDetailsOnButtonClick(isCollapsed) {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -355,13 +355,12 @@
       <footer class="card_footer">
         <template is="dom-if" if="[[isMode(modes.DISPLAY, mode)]]">
           <div id="detailsButton" on-click="toggleDetailsVisibility" class="expand-details-clickable">
-            <template is="dom-if" if="[[detailsExpanded]]">
-              <jha-up-arrow-icon></jha-up-arrow-icon>
-            </template>
-            <template is="dom-if" if="[[!detailsExpanded]]">
+            <template is="dom-if" if="[[detailsArrowIconDown]]">
               <jha-drop-arrow-icon></jha-drop-arrow-icon>
             </template>
-
+            <template is="dom-if" if="[[!detailsArrowIconDown]]">
+              <jha-up-arrow-icon></jha-up-arrow-icon>
+            </template>
           </div>
         </template>
       </footer>
@@ -588,8 +587,7 @@
         let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
 
         let isCollapsed = (this.isClass(animatedCollapsed) || this.isClass(defaultCollapsed));
-
-        let isListUpdate = typeof event === 'boolean';
+        let isListUpdate = (typeof event === 'boolean');
 
         if (isListUpdate) {
           this.setDisplayOnListUpdate(isCollapsed);
@@ -603,10 +601,8 @@
         let collapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
 
         this.userCardClass = this.isExpanded ? expanded : collapsed;
-        this.detailsExpanded = this.isExpanded;
 
-        console.log(this.user.first, this.userCardClass);
-
+        this.setDetailsArrowIcon();
       }
 
       setDisplayOnButtonClick(isCollapsed) {
@@ -614,11 +610,19 @@
         let expanded = this.classes.EXPAND_EXISTING;
 
         this.userCardClass = isCollapsed ? expanded : collapsed;
-        this.detailsExpanded = !this.detailsExpanded;
+
+        this.setDetailsArrowIcon();
+      }
+
+      setDetailsArrowIcon() {
+        let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
+        let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
+        this.detailsArrowIconDown = (this.isClass(animatedCollapsed) || this.isClass(defaultCollapsed));
       }
 
       editButtonClicked(e) {
         e.preventDefault();
+
         this.editInProgress(true);
         this.mode = this.modes.EDIT_EXISTING;
         this.toggleEditableInputs();

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -150,7 +150,7 @@
         transition: all .2s;
       }
 
-      /* EXISTING USER TRANSITIONS */
+      /* USER USER TRANSITIONS */
 
       .collapse-existing-user {
         height: 70px;
@@ -271,7 +271,7 @@
             <span>[[user.id]]</span>
           </div>
         </template>
-        <template is="dom-if" if="[[isMode(modes.EDIT_EXISTING, mode)]]">
+        <template is="dom-if" if="[[isMode(modes.EDIT_USER, mode)]]">
           <h1 class="edit-user-header">[[setEditUserHeader(user)]]</h1>
         </template>
         <template is="dom-if" if="[[isMode(modes.CREATE_NEW, mode)]]">
@@ -337,7 +337,7 @@
             <template is="dom-if" if="[[!isMode(modes.DISPLAY, mode)]]">
               <button class="save-button" on-click="save" type="submit" disabled="[[disableSave]]">Save</button>
 
-              <template is="dom-if" if="[[isMode(modes.EDIT_EXISTING, mode)]]">
+              <template is="dom-if" if="[[isMode(modes.EDIT_USER, mode)]]">
                 <button on-click="delete" type="submit" formnovalidate>Delete</button>
               </template>
               <br>
@@ -383,7 +383,7 @@
             value: () => {
               return {
                 DISPLAY: 'display',
-                EDIT_EXISTING: 'edit',
+                EDIT_USER: 'edit',
                 CREATE_NEW: 'create'
               };
             }
@@ -393,11 +393,11 @@
             value: () => {
               return {
                 COLLAPSE_NEW: 'default-card collapse-new-user',
-                COLLAPSE_EXISTING: 'default-card collapse-existing-user',
-                COLLAPSE_EXISTING_DEFAULT: 'default-card collapse-existing-user-default',
-                EXPAND_EXISTING_DEFAULT: 'default-card expand-existing-user-default',
+                ANIMATE_COLLAPSE_USER: 'default-card collapse-existing-user',
+                IMMEDIATELY_COLLAPSE_USER: 'default-card collapse-existing-user-default',
+                IMMEDIATELY_EXPAND_USER: 'default-card expand-existing-user-default',
                 EXPAND_NEW: 'default-card expand-new-user',
-                EXPAND_EXISTING: 'default-card expand-existing-user',
+                ANIMATE_EXPAND_USER: 'default-card expand-existing-user',
               };
             }
           },
@@ -571,8 +571,8 @@
       }
 
       saveCardState() {
-        let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
-        let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
+        let animatedCollapsed = this.classes.ANIMATE_COLLAPSE_USER;
+        let defaultCollapsed = this.classes.IMMEDIATELY_COLLAPSE_USER;
         let isExpanded = this.isClass(animatedCollapsed) || this.isClass(defaultCollapsed);
 
         this.dispatchEvent(new CustomEvent('cardDetailDisplayChanged', {
@@ -583,8 +583,8 @@
       }
 
       setUserDetailsDisplay(event) {
-        let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
-        let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
+        let animatedCollapsed = this.classes.ANIMATE_COLLAPSE_USER;
+        let defaultCollapsed = this.classes.IMMEDIATELY_COLLAPSE_USER;
 
         let isCollapsed = (this.isClass(animatedCollapsed) || this.isClass(defaultCollapsed));
         let isListUpdate = (typeof event === 'boolean');
@@ -597,8 +597,8 @@
       }
 
       setDisplayOnListUpdate(isCollapsed) {
-        let expanded = this.classes.EXPAND_EXISTING_DEFAULT;
-        let collapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
+        let expanded = this.classes.IMMEDIATELY_EXPAND_USER;
+        let collapsed = this.classes.IMMEDIATELY_COLLAPSE_USER;
 
         this.userCardClass = this.isExpanded ? expanded : collapsed;
 
@@ -606,8 +606,8 @@
       }
 
       setDisplayOnButtonClick(isCollapsed) {
-        let collapsed = this.classes.COLLAPSE_EXISTING;
-        let expanded = this.classes.EXPAND_EXISTING;
+        let collapsed = this.classes.ANIMATE_COLLAPSE_USER;
+        let expanded = this.classes.ANIMATE_EXPAND_USER;
 
         this.userCardClass = isCollapsed ? expanded : collapsed;
 
@@ -615,8 +615,8 @@
       }
 
       setDetailsArrowIcon() {
-        let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
-        let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
+        let animatedCollapsed = this.classes.ANIMATE_COLLAPSE_USER;
+        let defaultCollapsed = this.classes.IMMEDIATELY_COLLAPSE_USER;
         this.detailsArrowIconDown = (this.isClass(animatedCollapsed) || this.isClass(defaultCollapsed));
       }
 
@@ -624,7 +624,7 @@
         e.preventDefault();
 
         this.editInProgress(true);
-        this.mode = this.modes.EDIT_EXISTING;
+        this.mode = this.modes.EDIT_USER;
         this.toggleEditableInputs();
       }
 
@@ -641,7 +641,7 @@
       }
 
       toggleEditDisplayMode(e) {
-        this.mode = this.isMode(this.modes.EDIT_EXISTING) ? this.modes.DISPLAY : this.modes.EDIT_EXISTING;
+        this.mode = this.isMode(this.modes.EDIT_USER) ? this.modes.DISPLAY : this.modes.EDIT_USER;
       }
 
       toggleEditableInputs() {
@@ -654,7 +654,7 @@
       resetFormState() {
         this.editInProgress(false);
 
-        if (this.isMode(this.modes.EDIT_EXISTING)) {
+        if (this.isMode(this.modes.EDIT_USER)) {
           this.toggleEditDisplayMode();
           this.toggleEditableInputs();
         } else {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -223,8 +223,7 @@
       }
 
       .expand-existing-user-default>.card_footer>.expand-details-clickable {
-        background-color: red;
-        /* background-color: #0070b7; */
+        background-color: #0070b7;
         cursor: pointer;
       }
 

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -593,13 +593,13 @@
         let isListUpdate = typeof event === 'boolean';
 
         if (isListUpdate) {
-          this.setDetailsOnListUpdate(isCollapsed);
+          this.setDisplayOnListUpdate(isCollapsed);
         } else {
-          this.setDetailsOnButtonClick(isCollapsed);
+          this.setDisplayOnButtonClick(isCollapsed);
         }
       }
 
-      setDetailsOnListUpdate(isCollapsed) {
+      setDisplayOnListUpdate(isCollapsed) {
         let expanded = this.classes.EXPAND_EXISTING_DEFAULT;
         let collapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
 
@@ -610,7 +610,7 @@
 
       }
 
-      setDetailsOnButtonClick(isCollapsed) {
+      setDisplayOnButtonClick(isCollapsed) {
         let collapsed = this.classes.COLLAPSE_EXISTING;
         let expanded = this.classes.EXPAND_EXISTING;
 

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -355,10 +355,10 @@
       <footer class="card_footer">
         <template is="dom-if" if="[[isMode(modes.DISPLAY, mode)]]">
           <div id="detailsButton" on-click="toggleIsExpanded" class="expand-details-clickable">
-            <template is="dom-if" if="[[isClass(classes.EXPAND_EXISTING, userCardClass)]]">
+            <template is="dom-if" if="[[detailsExpanded]]">
               <jha-up-arrow-icon></jha-up-arrow-icon>
             </template>
-            <template is="dom-if" if="[[isClass(classes.COLLAPSE_EXISTING, userCardClass)]]">
+            <template is="dom-if" if="[[!detailsExpanded]]">
               <jha-drop-arrow-icon></jha-drop-arrow-icon>
             </template>
 
@@ -447,7 +447,7 @@
           },
           isExpanded: {
             type: Boolean,
-            observer: 'setUserCardDisplayState'
+            observer: 'setUserDetailsDisplay'
           },
           // passed in from parent of user-component
           userToDisplay: {
@@ -567,7 +567,7 @@
         return fieldsFilled;
       }
 
-      setUserCardDisplayState(event) {
+      setUserDetailsDisplay(event) {
         let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
         let animatedExpanded = this.classes.EXPAND_EXISTING;
         let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
@@ -578,22 +578,26 @@
         let isListUpdate = typeof event === 'boolean';
 
         if (isListUpdate) {
-          this.setListUpdateCardState(isCollapsed)
+          this.setDetailsOnListUpdate(isCollapsed);
         } else {
-          this.setClickEventCardState(isCollapsed);
+          this.setDetailsOnButtonClick(isCollapsed);
         }
       }
 
-      setListUpdateCardState(isCollapsed) {
+      setDetailsOnListUpdate(isCollapsed) {
         let expanded = this.classes.EXPAND_EXISTING_DEFAULT;
         let collapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
+
         this.userCardClass = this.isExpanded ? expanded : collapsed;
+        this.detailsExpanded = this.isExpanded;
       }
 
-      setClickEventCardState(isCollapsed) {
+      setDetailsOnButtonClick(isCollapsed) {
         let collapsed = this.classes.COLLAPSE_EXISTING;
         let expanded = this.classes.EXPAND_EXISTING;
+
         this.userCardClass = isCollapsed ? expanded : collapsed;
+        this.detailsExpanded = !this.detailsExpanded;
       }
 
       toggleIsExpanded() {
@@ -607,7 +611,7 @@
           detail: { id: this.user.id, expanded: isExpanded }
         }));
 
-        this.setUserCardDisplayState();
+        this.setUserDetailsDisplay();
       }
 
       editButtonClicked(e) {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -354,7 +354,7 @@
       </div>
       <footer class="card_footer">
         <template is="dom-if" if="[[isMode(modes.DISPLAY, mode)]]">
-          <div id="detailsButton" on-click="toggleIsExpanded" class="expand-details-clickable">
+          <div id="detailsButton" on-click="toggleDetailsVisibility" class="expand-details-clickable">
             <template is="dom-if" if="[[detailsExpanded]]">
               <jha-up-arrow-icon></jha-up-arrow-icon>
             </template>
@@ -567,6 +567,23 @@
         return fieldsFilled;
       }
 
+      toggleDetailsVisibility() {
+        this.saveCardState();
+        this.setUserDetailsDisplay();
+      }
+
+      saveCardState() {
+        let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
+        let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
+        let isExpanded = this.isClass(animatedCollapsed) || this.isClass(defaultCollapsed);
+
+        this.dispatchEvent(new CustomEvent('cardDetailDisplayToggled', {
+          bubbles: true,
+          composed: true,
+          detail: { id: this.user.id, expanded: isExpanded }
+        }));
+      }
+
       setUserDetailsDisplay(event) {
         let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
         let animatedExpanded = this.classes.EXPAND_EXISTING;
@@ -598,20 +615,6 @@
 
         this.userCardClass = isCollapsed ? expanded : collapsed;
         this.detailsExpanded = !this.detailsExpanded;
-      }
-
-      toggleIsExpanded() {
-        let animatedCollapsed = this.classes.COLLAPSE_EXISTING;
-        let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
-        let isExpanded = this.isClass(animatedCollapsed) || this.isClass(defaultCollapsed);
-
-        this.dispatchEvent(new CustomEvent('cardDetailDisplayToggled', {
-          bubbles: true,
-          composed: true,
-          detail: { id: this.user.id, expanded: isExpanded }
-        }));
-
-        this.setUserDetailsDisplay();
       }
 
       editButtonClicked(e) {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -575,7 +575,7 @@
         let defaultCollapsed = this.classes.COLLAPSE_EXISTING_DEFAULT;
         let isExpanded = this.isClass(animatedCollapsed) || this.isClass(defaultCollapsed);
 
-        this.dispatchEvent(new CustomEvent('cardDetailDisplayToggled', {
+        this.dispatchEvent(new CustomEvent('cardDetailDisplayChanged', {
           bubbles: true,
           composed: true,
           detail: { id: this.user.id, expanded: isExpanded }

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -95,6 +95,10 @@
             type: Boolean,
             value: false
           },
+          expandedCardIds: {
+            type: Array,
+            value: []
+          },
           users: {
             type: Array,
             value: () => Database.getUsers()
@@ -117,6 +121,24 @@
           this.editInProgress = e.detail;
         });
 
+        document.addEventListener('cardDetailDisplayToggled', (e) => {
+          const id = e.detail.id
+          let expanded = e.detail.expanded;
+          return expanded ? this.addIdToExpanded(id) : this.removeIdFromExpanded(id);
+        });
+
+      }
+
+      addIdToExpanded(id) {
+        this.expandedCardIds.splice(0, 0, id);
+      }
+
+      removeIdFromExpanded(id) {
+        // console.log('b');
+        // let expandedIds = this.expandedCardIds;
+        // expandedIds.forEach(expandedId => {
+
+        // });
       }
 
       disconnectedCallback() {

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -74,7 +74,7 @@
             </div>
           </template>
           <template is="dom-repeat" items="[[users]]" as="user">
-            <user-component edit-open="[[editInProgress]]" is-expanded="[[setExpanded(user.id, users)]]" user-to-display="[[user]]"></user-component>
+            <user-component edit-open="[[editInProgress]]" is-expanded="[[isExpanded(user.id, users)]]" user-to-display="[[user]]"></user-component>
           </template>
         </div>
       </div>
@@ -113,6 +113,8 @@
         });
 
         document.addEventListener('databaseUpdated', e => {
+          console.log(this.expandedCardIds);
+
           this.users = Database.getUsers();
           this.popupMessage(e.detail.message);
         });
@@ -122,7 +124,7 @@
         });
 
         document.addEventListener('cardDetailDisplayToggled', (e) => {
-          const id = e.detail.id
+          const id = e.detail.id;
           let expanded = e.detail.expanded;
           return expanded ? this.addIdToExpanded(id) : this.removeIdFromExpanded(id);
         });
@@ -133,12 +135,12 @@
         this.expandedCardIds.splice(0, 0, id);
       }
 
-      removeIdFromExpanded(id) {
-        // console.log('b');
-        // let expandedIds = this.expandedCardIds;
-        // expandedIds.forEach(expandedId => {
+      removeIdFromExpanded(idToDelete) {
+        let idIndex = this.expandedCardIds.findIndex(id => {
+          return id === idToDelete;
+        });
 
-        // });
+        this.expandedCardIds.splice(idIndex, 1);
       }
 
       disconnectedCallback() {
@@ -162,10 +164,11 @@
         }, animationTime);
       }
 
-      setExpanded(userId) {
+      isExpanded(userId) {
         let isExpanded = false;
         this.expandedCardIds.forEach(id => {
           if (id === userId) {
+
             isExpanded = true;
           }
         });

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -43,6 +43,7 @@
         opacity: 0;
         transform: translateY(100%);
         transition: all 600ms cubic-bezier(0.77, 0, 0.175, 1);
+        z-index: 1;
       }
 
       .show-message {

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -113,8 +113,6 @@
         });
 
         document.addEventListener('databaseUpdated', e => {
-          console.log(this.expandedCardIds);
-
           this.users = Database.getUsers();
           this.popupMessage(e.detail.message);
         });

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -124,16 +124,16 @@
         document.addEventListener('cardDetailDisplayChanged', (e) => {
           const id = e.detail.id;
           let expanded = e.detail.expanded;
-          return expanded ? this.addIdToExpanded(id) : this.removeIdFromExpanded(id);
+          return expanded ? this.addIdToExpandedList(id) : this.removeIdFromExpandedList(id);
         });
 
       }
 
-      addIdToExpanded(id) {
+      addIdToExpandedList(id) {
         this.expandedCardIds.splice(0, 0, id);
       }
 
-      removeIdFromExpanded(idToDelete) {
+      removeIdFromExpandedList(idToDelete) {
         let idIndex = this.expandedCardIds.findIndex(id => {
           return id === idToDelete;
         });

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -28,18 +28,18 @@
       }
 
       .message-box {
-        background-color: #4caf50;
+        background-color: #455564;
         color: #eef1f4;
         position: fixed;
         bottom: 10px;
         left: 10px;
         font-family: Arial, Helvetica, sans-serif;
-        font-size: 25px;
+        font-size: 16px;
         height: auto;
-        width: 15%;
+        width: 250px;
         margin: 20px;
         padding: 10px;
-        text-align: center;
+        text-align: left;
         opacity: 0;
         transform: translateY(100%);
         transition: all 600ms cubic-bezier(0.77, 0, 0.175, 1);

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -74,7 +74,7 @@
             </div>
           </template>
           <template is="dom-repeat" items="[[users]]" as="user">
-            <user-component edit-open="[[editInProgress]]" is-expanded="[[isExpanded(user.id, users)]]" user-to-display="[[user]]"></user-component>
+            <user-component edit-open="[[editInProgress]]" is-expanded="[[isUserCardDisplayExpanded(user.id, users)]]" user-to-display="[[user]]"></user-component>
           </template>
         </div>
       </div>
@@ -162,7 +162,7 @@
         }, animationTime);
       }
 
-      isExpanded(userId) {
+      isUserCardDisplayExpanded(userId) {
         let isExpanded = false;
         this.expandedCardIds.forEach(id => {
           if (id === userId) {

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -121,7 +121,7 @@
           this.editInProgress = e.detail;
         });
 
-        document.addEventListener('cardDetailDisplayToggled', (e) => {
+        document.addEventListener('cardDetailDisplayChanged', (e) => {
           const id = e.detail.id;
           let expanded = e.detail.expanded;
           return expanded ? this.addIdToExpanded(id) : this.removeIdFromExpanded(id);

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -74,7 +74,7 @@
             </div>
           </template>
           <template is="dom-repeat" items="[[users]]" as="user">
-            <user-component edit-open="[[editInProgress]]" user-to-display="[[user]]"></user-component>
+            <user-component edit-open="[[editInProgress]]" is-expanded="[[setExpanded(user.id, users)]]" user-to-display="[[user]]"></user-component>
           </template>
         </div>
       </div>
@@ -160,6 +160,17 @@
         window.setTimeout(() => {
           messageBox.className = 'message-box';
         }, animationTime);
+      }
+
+      setExpanded(userId) {
+        let isExpanded = false;
+        this.expandedCardIds.forEach(id => {
+          if (id === userId) {
+            isExpanded = true;
+          }
+        });
+
+        return isExpanded;
       }
     }
 


### PR DESCRIPTION
## What It Does

When the screen width is too small the text of the popup message would overflow. This sets the width to a static 250px rather than by percentage. It also changes the style of the toast message box a bit to match the current color scheme.

## How To Test

Create, delete, or save an edit on a new user at various screen widths. The popup message should display properly.

## Notes/Caveats

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [x] Updated the docs, if necessary
- [x] Included the appropriate labels
- [x] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)

Browsers tested:
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] ~Edge~
- [ ] ~Internet Explorer~

## Dependencies

- [ ] None
