### PR TITLE
Sort Name Mini Project: Sorting Display Styles

### DIFF
--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -106,6 +106,16 @@
             type: Array,
             value: []
           },
+          sortFilters: {
+            type: Object,
+            value: () => {
+              return {
+                FIRST_NAME: 'first',
+                LAST_NAME: 'last',
+                DEPARTMENT: 'department'
+              }
+            }
+          },
           users: {
             type: Array,
             value: () => Database.getUsers()
@@ -137,20 +147,16 @@
 
       sortUsers(e) {
         let sorted;
-        let filters = {
-          FIRST_NAME: 'first',
-          LAST_NAME: 'last',
-          DEPARTMENT: 'department'
-        };
+        let sortBy = this.sortFilters;
 
         if (e.target.value === 'First Name') {
-          sorted = SortUtil.sortUsersBy(this.users, filters.FIRST_NAME, filters.LAST_NAME, filters.DEPARTMENT);
+          sorted = SortUtil.sortUsersBy(this.users, sortBy.FIRST_NAME, sortBy.LAST_NAME, sortBy.DEPARTMENT);
         }
         if (e.target.value === 'Last Name') {
-          sorted = SortUtil.sortUsersBy(this.users);
+          sorted = SortUtil.sortUsersBy(this.users, sortBy.LAST_NAME, sortBy.FIRST_NAME, sortBy.DEPARTMENT);
         }
         if (e.target.value === 'Department') {
-          sorted = SortUtil.sortUsersBy(this.users, filters.DEPARTMENT, filters.LAST_NAME, filters.FIRST_NAME);
+          sorted = SortUtil.sortUsersBy(this.users, sortBy.DEPARTMENT, sortBy.LAST_NAME, sortBy.FIRST_NAME);
         }
 
         this.users = [];

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -62,9 +62,9 @@
       .category-header {
         position: relative;
         margin: 50px 0px 40px 0px;
-        left: -40px;
+        left: -30px;
         border-bottom: black solid 2px;
-        width: 500px;
+        width: calc(100%+20px);
       }
 
       .category-header>.category-text {
@@ -132,7 +132,7 @@
                 FIRST_NAME: 'first',
                 LAST_NAME: 'last',
                 DEPARTMENT: 'department'
-              }
+              };
             }
           },
           currentSortFilter: {
@@ -240,7 +240,7 @@
         let previousUser = users[index - 1];
         let currentUser = users[index];
         let category = this.currentSortFilter;
-        let isFirstInList = !previousUser
+        let isFirstInList = !previousUser;
 
         if (previousUser) {
           let previousUserCategoryLetter = previousUser[category].slice(0, 1);
@@ -253,7 +253,7 @@
 
       setNewGroupHeader(user, index) {
         let category = this.currentSortFilter;
-        let categoryIsDepartment = category === this.sortFilters.DEPARTMENT
+        let categoryIsDepartment = category === this.sortFilters.DEPARTMENT;
         let firstLetterOfCategory = user[category].slice(0, 1);
 
         return categoryIsDepartment ? `${user.department}` : `${firstLetterOfCategory}`;

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -128,7 +128,7 @@
           },
           currentSortFilter: {
             type: String,
-            value: 'department'
+            value: 'last'
           },
           users: {
             type: Array,
@@ -165,12 +165,15 @@
 
         if (e.target.value === 'First Name') {
           sorted = SortUtil.sortUsersBy(this.users, sortBy.FIRST_NAME, sortBy.LAST_NAME, sortBy.DEPARTMENT);
+          this.currentSortFilter = sortBy.FIRST_NAME;
         }
         if (e.target.value === 'Last Name') {
           sorted = SortUtil.sortUsersBy(this.users, sortBy.LAST_NAME, sortBy.FIRST_NAME, sortBy.DEPARTMENT);
+          this.currentSortFilter = sortBy.LAST_NAME;
         }
         if (e.target.value === 'Department') {
           sorted = SortUtil.sortUsersBy(this.users, sortBy.DEPARTMENT, sortBy.LAST_NAME, sortBy.FIRST_NAME);
+          this.currentSortFilter = sortBy.DEPARTMENT;
         }
 
         this.users = [];

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -59,10 +59,18 @@
         box-shadow: rgba(0, 0, 0, 0.14902) 0px 1px 1px 0px, rgba(0, 0, 0, 0.09804) 0px 1px 2px 0px;
       }
 
-      hr {
-        color: black;
-        background-color: black;
-        height: 10px;
+      .category-header {
+        position: relative;
+        margin: 50px 0px 40px 0px;
+        left: -40px;
+        border-bottom: black solid 2px;
+        width: 500px;
+      }
+
+      .category-header>.category-text {
+        position: absolute;
+        bottom: 10px;
+        left: 10px;
       }
     </style>
     <div class="columns">
@@ -87,8 +95,9 @@
           </template>
           <template is="dom-repeat" items="[[users]]" as="user">
             <template is="dom-if" if="[[isFirstWithNewLetter(index, users)]]">
-              <div>[[setNewGroupHeader(user)]]</div>
-              <hr>
+              <div class="category-header">
+                <div class="category-text">[[setNewGroupHeader(user, index)]]</div>
+              </div>
             </template>
             <user-component edit-open="[[editInProgress]]" is-expanded="[[isUserCardDisplayExpanded(user.id, users)]]" user-to-display="[[user]]"></user-component>
           </template>
@@ -128,7 +137,6 @@
           },
           currentSortFilter: {
             type: String,
-            value: 'last'
           },
           users: {
             type: Array,
@@ -138,6 +146,8 @@
       }
       connectedCallback() {
         super.connectedCallback();
+
+        this.currentSortFilter = 'last';
 
         document.addEventListener('cancel', () => {
           this.toggleMode();
@@ -233,8 +243,6 @@
 
         // property to match category
         if (previousUser) {
-          console.log();
-
 
           let previousUserCategoryLetter = previousUser[category].slice(0, 1);
           let currentUserCategoryLetter = currentUser[category].slice(0, 1);
@@ -244,14 +252,12 @@
         return !previousUser;
       }
 
-      setNewGroupHeader(user) {
+      setNewGroupHeader(user, index) {
         let category = this.currentSortFilter;
-        if (category === 'department') {
-          return `${user.department}`
-        } else {
-          let firstLetter = user[category].slice(0, 1);
-          return `${firstLetter}`
-        }
+        let categoryIsDepartment = category === this.sortFilters.DEPARTMENT
+        let firstLetterOfCategory = user[category].slice(0, 1);
+
+        return categoryIsDepartment ? `${user.department}` : `${firstLetterOfCategory}`;
       }
     }
 

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -58,6 +58,12 @@
         border-radius: 3px;
         box-shadow: rgba(0, 0, 0, 0.14902) 0px 1px 1px 0px, rgba(0, 0, 0, 0.09804) 0px 1px 2px 0px;
       }
+
+      hr {
+        color: black;
+        background-color: black;
+        height: 10px;
+      }
     </style>
     <div class="columns">
       <div class="column-1">
@@ -75,14 +81,15 @@
         </div>
         <div class="user-list-row">
           <template is="dom-if" if="[[noUsersHeaderMessage(users)]]">
-            <template is="dom-if" if="[[isFirstWithNewLetter(index, users)]]">
-              <hr>
-            </template>
             <div class="no-users">
               <p>There aren't any users in the database at the moment. Would you mind creating one to get started?</p>
             </div>
           </template>
           <template is="dom-repeat" items="[[users]]" as="user">
+            <template is="dom-if" if="[[isFirstWithNewLetter(index, users)]]">
+              <div>[[setNewGroupHeader(user)]]</div>
+              <hr>
+            </template>
             <user-component edit-open="[[editInProgress]]" is-expanded="[[isUserCardDisplayExpanded(user.id, users)]]" user-to-display="[[user]]"></user-component>
           </template>
         </div>
@@ -118,6 +125,10 @@
                 DEPARTMENT: 'department'
               }
             }
+          },
+          currentSortFilter: {
+            type: String,
+            value: 'department'
           },
           users: {
             type: Array,
@@ -212,24 +223,32 @@
       }
 
       isFirstWithNewLetter(index, users) {
-        let previousUser = index - 1;
-        let currentUser = index;
 
-        // current filter category
+        let previousUser = users[index - 1];
+        let currentUser = users[index];
+        let category = this.currentSortFilter;
 
         // property to match category
-
-        // first letter of property that matches category (previous)
-        // first letter of property that matches category (current)
-
-        // return previous === current
+        if (previousUser) {
+          console.log();
 
 
+          let previousUserCategoryLetter = previousUser[category].slice(0, 1);
+          let currentUserCategoryLetter = currentUser[category].slice(0, 1);
 
+          return previousUserCategoryLetter !== currentUserCategoryLetter;
+        }
+        return !previousUser;
+      }
 
-        // If department return department name
-
-
+      setNewGroupHeader(user) {
+        let category = this.currentSortFilter;
+        if (category === 'department') {
+          return `${user.department}`
+        } else {
+          let firstLetter = user[category].slice(0, 1);
+          return `${firstLetter}`
+        }
       }
     }
 

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -75,6 +75,9 @@
         </div>
         <div class="user-list-row">
           <template is="dom-if" if="[[noUsersHeaderMessage(users)]]">
+            <template is="dom-if" if="[[isFirstWithNewLetter(index, users)]]">
+              <hr>
+            </template>
             <div class="no-users">
               <p>There aren't any users in the database at the moment. Would you mind creating one to get started?</p>
             </div>
@@ -206,6 +209,27 @@
         });
 
         return isExpanded;
+      }
+
+      isFirstWithNewLetter(index, users) {
+        let previousUser = index - 1;
+        let currentUser = index;
+
+        // current filter category
+
+        // property to match category
+
+        // first letter of property that matches category (previous)
+        // first letter of property that matches category (current)
+
+        // return previous === current
+
+
+
+
+        // If department return department name
+
+
       }
     }
 

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -94,7 +94,7 @@
             </div>
           </template>
           <template is="dom-repeat" items="[[users]]" as="user">
-            <template is="dom-if" if="[[isFirstWithNewLetter(index, users)]]">
+            <template is="dom-if" if="[[isFirstWithNewLetter(users, index)]]">
               <div class="category-header">
                 <div class="category-text">[[setNewGroupHeader(user, index)]]</div>
               </div>
@@ -235,21 +235,20 @@
         return isExpanded;
       }
 
-      isFirstWithNewLetter(index, users) {
+      isFirstWithNewLetter(users, index) {
 
         let previousUser = users[index - 1];
         let currentUser = users[index];
         let category = this.currentSortFilter;
+        let isFirstInList = !previousUser
 
-        // property to match category
         if (previousUser) {
-
           let previousUserCategoryLetter = previousUser[category].slice(0, 1);
           let currentUserCategoryLetter = currentUser[category].slice(0, 1);
 
           return previousUserCategoryLetter !== currentUserCategoryLetter;
         }
-        return !previousUser;
+        return isFirstInList;
       }
 
       setNewGroupHeader(user, index) {


### PR DESCRIPTION
## What It Does

Adds visual alphabetization for sorted categories. When sorting departments, it actually displays the departments as well.

The problem with sorting departments or first names is that it takes a hot second to adjust to the new sort. First names are visible, but the first name sort is not immediately intuitive because of the Last, First display order. Departments are not even shown in the collapsed state of cards. 

I added a dom-if template to each dom-repeated user card that is only displayed if it is the first card in a new sorted category. So if the users name is Bob and the previous user was Annie, then the header will be displayed there.

The letter displayed is set dynamically by grabbing the first letter of the sorted category. So if you are sorting first names, and Bob is the first B, then it grabs the B off the front of the name to use to display the category.

In the case of Departments, it figures out when to display the category header in the same way, but instead of grabbing the first letter, it grabs the entire department name.

#114 

## How To Test

Create various users with various first and last names and departments. Having some users with overlapping First, Last, or Department names will more effectively test the filters.

## Checklist

Under penalty of public shaming, I avow that I:

- [ ] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [ ] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [ ] Updated the docs, if necessary
- [x] Included the appropriate labels
- [ ] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)

Browsers tested:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer

## Dependencies

- [ ] #115 
