### PR TITLE
Mini-Project: Phone Symbols Bug

### DIFF
--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -485,8 +485,12 @@
       }
 
       formatIncomingUserData(user) {
-        user.phone = ValidateUtil.formatPhoneNumber(user.phone);
-        this.user = user;
+        let doesNotHaveSymbols = !user.phone.match(/\D/g);
+
+        if (doesNotHaveSymbols) {
+          user.phone = ValidateUtil.formatPhoneNumber(user.phone);
+          this.user = user;
+        }
       }
 
       save(e) {


### PR DESCRIPTION
## What It Does

Squashes bug that caused extra symbols to be inserted into phone numbers on each sort.

It was a bug, it looked ugly.

A quick regex check to see if the user already had phone symbols before trying to insert them.

## How To Test

Sort users multiple times, users phone numbers should still be formatted correctly.

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [ ] Updated the docs, if necessary
- [ ] Included the appropriate labels
- [ ] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)

Browsers tested:
- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer
