### PR TITLE
Sort Users Mini Project: Refactor – Move Sort to Database API

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -30,7 +30,7 @@ Under penalty of public shaming, I avow that I:
 - [ ] Updated the docs, if necessary
 - [ ] Included the appropriate labels
 - [ ] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)
-- [ ] Verified that you are merging into the correct branch
+- [ ] ARE YOU MERGING INTO THE CORRECT BRANCH!?
 
 Browsers tested:
 

--- a/src/api/user-database.js
+++ b/src/api/user-database.js
@@ -13,25 +13,6 @@ class Database {
     return match;
   }
 
-  static editUser(user) {
-    let users = this.getUsers();
-    let popupMessage = "Edit Save";
-
-    users.splice(this.getIdIndex(user.id), 1, this.formatUserData(user));
-
-    this.updateLocalStorage(users, popupMessage);
-  }
-
-  static saveUser(user) {
-    let users = this.getUsers() ? this.getUsers() : [];
-    let popupMessage = "Save";
-
-    users.splice(0, 0, this.formatUserData(user));
-    let sorted = this.getUsersSortedBy(["last", "first", "department"]);
-
-    this.updateLocalStorage(sorted, popupMessage);
-  }
-
   static getUsersSortedBy(filters) {
     let users = JSON.parse(localStorage.getItem("onboardProjectUsers")) || [];
     let sortFilters = filters.length ? filters : this.fallbackFilters();
@@ -42,6 +23,28 @@ class Database {
     });
 
     return sorted;
+  }
+
+  static fallbackFilters() {
+    return ["last", "first", "department"];
+  }
+
+  static editUser(user) {
+    let users = this.getUsers();
+    let popupMessage = "Edit Save";
+
+    users.splice(this.getIdIndex(user.id), 1, this.formatUserData(user));
+
+    this.updateLocalStorage(users, popupMessage);
+  }
+
+  static saveUser(user) {
+    let users = this.getUsers();
+    let popupMessage = "Save";
+
+    users.splice(0, 0, this.formatUserData(user));
+
+    this.updateLocalStorage(users, popupMessage);
   }
 
   static compareTwoUsers(a, b, filters) {
@@ -57,10 +60,6 @@ class Database {
     return compared;
   }
 
-  static fallbackFilters() {
-    return ["last", "first", "department"];
-  }
-
   static deleteUser(user) {
     let users = this.getUsers();
     let popupMessage = "Delete";
@@ -71,12 +70,14 @@ class Database {
   }
 
   static deleteAllUsers() {
-    localStorage.setItem("onboardProjectUsers", JSON.stringify([]));
+    let popupMessage = "Delete All Users";
+    this.updateLocalStorage([], popupMessage);
   }
 
   static getIdIndex(userId) {
     let users = this.getUsers();
     let userIndex = users ? users.findIndex(user => user.id === userId) : -1;
+
     return userIndex;
   }
 
@@ -85,6 +86,7 @@ class Database {
     user.last = this.titleCaseName(user.last);
     user.id = user.id || this.createNewUserId();
     user.phone = this.getOnlyPhoneDigits(user.phone);
+
     return user;
   }
 
@@ -95,6 +97,7 @@ class Database {
   static titleCaseName(name) {
     let firstLetter = name.charAt(0).toUpperCase();
     let restOfName = name.slice(1).toLowerCase();
+
     return `${firstLetter}${restOfName}`;
   }
 
@@ -124,6 +127,7 @@ class Database {
     }
 
     let idAlreadyExists = this.getIdIndex(id) !== -1;
+
     return idAlreadyExists ? this.createNewUserId() : id;
   }
 }

--- a/src/api/user-database.js
+++ b/src/api/user-database.js
@@ -27,19 +27,38 @@ class Database {
     let popupMessage = "Save";
 
     users.splice(0, 0, this.formatUserData(user));
-    let sorted = this.sortUsersByLastName(users);
+    let sorted = this.getUsersSortedBy(["last", "first", "department"]);
 
     this.updateLocalStorage(sorted, popupMessage);
   }
 
-  static sortUsersByLastName(users) {
-    return users.sort((a, b) => {
-      if (a.last === b.last) {
-        return 0;
-      } else {
-        return a.last > b.last ? 1 : -1;
+  static getUsersSortedBy(filters) {
+    let users = JSON.parse(localStorage.getItem("onboardProjectUsers")) || [];
+    let sortFilters = filters.length ? filters : this.fallbackFilters();
+    sortFilters.reverse();
+
+    let sorted = users.sort((a, b) => {
+      return this.compareTwoUsers(a, b, sortFilters);
+    });
+
+    return sorted;
+  }
+
+  static compareTwoUsers(a, b, filters) {
+    let compared = 0;
+
+    filters.forEach(filter => {
+      if (a[filter] !== b[filter]) {
+        compared = a[filter] > b[filter] ? 1 : -1;
+        return;
       }
     });
+
+    return compared;
+  }
+
+  static fallbackFilters() {
+    return ["last", "first", "department"];
   }
 
   static deleteUser(user) {

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -62,39 +62,6 @@ class ValidateUtil {
   }
 }
 
-// create fallback defaults for each one
-
-class SortUtil {
-  static fallbackFilters() {
-    return ["last", "first", "department"];
-  }
-
-  static compareTwoUsers(a, b, filters) {
-    let compared = 0;
-
-    filters.forEach(filter => {
-      if (a[filter] !== b[filter]) {
-        compared = a[filter] > b[filter] ? 1 : -1;
-        return;
-      }
-    });
-
-    return compared;
-  }
-
-  static sortUsersBy(users, ...filters) {
-    let sortFilters = filters.length ? filters : this.fallbackFilters();
-    sortFilters.reverse();
-
-    let sorted = users.sort((a, b) => {
-      return this.compareTwoUsers(a, b, sortFilters);
-    });
-
-    return sorted;
-  }
-}
-
 module.exports = {
-  ValidateUtil: ValidateUtil,
-  SortUtil: SortUtil
+  ValidateUtil: ValidateUtil
 };

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -173,17 +173,17 @@
               </div>
               <hr>
               <div class="dropdown-options">
-                <li id="last" on-click="sortUsers">Last
+                <li id="last" on-click="setSortedUsersBy">Last
                   <template is="dom-if" if="[[sortFilterIs(sortFilters.LAST_NAME, currentSortFilter)]]">
                     ✓
                   </template>
                 </li>
-                <li id="first" on-click="sortUsers">First
+                <li id="first" on-click="setSortedUsersBy">First
                   <template is="dom-if" if="[[sortFilterIs(sortFilters.FIRST_NAME, currentSortFilter)]]">
                     ✓
                   </template>
                 </li>
-                <li id="department" on-click="sortUsers">Department
+                <li id="department" on-click="setSortedUsersBy">Department
                   <template is="dom-if" if="[[sortFilterIs(sortFilters.DEPARTMENT, currentSortFilter)]]">
                     ✓
                   </template>
@@ -279,7 +279,7 @@
         });
 
         document.addEventListener('databaseUpdated', e => {
-          this.sortUsers(this.currentSortFilter);
+          this.setSortedUsersBy(this.currentSortFilter);
           this.popupMessage(e.detail.message);
 
           if (e.detail.message === 'Edit Save') {
@@ -298,7 +298,7 @@
         });
       }
 
-      sortUsers(sortFilter) {
+      setSortedUsersBy(sortFilter) {
         let filters = this.sortFilters;
         let isDropdownSelection = Boolean(sortFilter.target);
         let sortBy;
@@ -321,7 +321,7 @@
 
       sortByDirection(e) {
         this.sortDirectionIsReversed = e.target.id === 'sortReversedAlphabetical';
-        this.sortUsers(this.currentSortFilter);
+        this.setSortedUsersBy(this.currentSortFilter);
       }
 
       addIdToExpandedList(id) {

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -173,18 +173,18 @@
               </div>
               <hr>
               <div class="dropdown-options">
-                <li on-click="dropdownSort">Last
-                  <template is="dom-if" if="[[sortFilterIs(sortFilters.LAST_NAME, currentSortFilter)]]">
+                <li id="last" on-click="sortUsers">Last
+                  <template is="dom-if" if="[[primarySortFilterIs(sortFilters.LAST_NAME, currentSortFilters)]]">
                     ✓
                   </template>
                 </li>
-                <li on-click="dropdownSort">First
-                  <template is="dom-if" if="[[sortFilterIs(sortFilters.FIRST_NAME, currentSortFilter)]]">
+                <li id="first" on-click="sortUsers">First
+                  <template is="dom-if" if="[[primarySortFilterIs(sortFilters.FIRST_NAME, currentSortFilters)]]">
                     ✓
                   </template>
                 </li>
-                <li on-click="dropdownSort">Department
-                  <template is="dom-if" if="[[sortFilterIs(sortFilters.DEPARTMENT, currentSortFilter)]]">
+                <li id="department" on-click="sortUsers">Department
+                  <template is="dom-if" if="[[primarySortFilterIs(sortFilters.DEPARTMENT, currentSortFilters)]]">
                     ✓
                   </template>
                 </li>
@@ -256,9 +256,9 @@
               };
             }
           },
-          currentSortFilter: {
-            type: String,
-            value: 'last'
+          currentSortFilters: {
+            type: Array,
+            value: ['last']
           },
           sortDirectionIsReversed: {
             type: Boolean,
@@ -266,13 +266,13 @@
           },
           users: {
             type: Array,
-            value: () => Database.getUsers()
+            value: () => Database.getUsersSortedBy(['last', 'first', 'department'])
           }
         };
       }
       connectedCallback() {
         super.connectedCallback();
-        this.sortUsers(this.sortFilters.LAST_NAME);
+
 
         document.addEventListener('cancel', () => {
           this.toggleMode();
@@ -280,7 +280,7 @@
 
         document.addEventListener('databaseUpdated', e => {
           this.users = Database.getUsers();
-          this.sortUsers(this.currentSortFilter);
+          this.sortUsers(this.currentSortFilters);
           this.popupMessage(e.detail.message);
 
           if (e.detail.message === 'Edit Save') {
@@ -299,48 +299,33 @@
         });
       }
 
-      dropdownSort(e) {
+      sortUsers(sortFilter) {
+        let filters = this.sortFilters;
+        let isDropdownSelection = sortFilter.target.id
         let sortBy;
+        let primaryFilterIs = isDropdownSelection ? sortFilter.target.id : sortFilter;
 
-        if (e.target.innerText === 'First') {
-          sortBy = this.sortFilters.FIRST_NAME;
+        if (primaryFilterIs === filters.FIRST_NAME) {
+          sortBy = [filters.FIRST_NAME, filters.LAST_NAME, filters.DEPARTMENT];
         }
-        if (e.target.innerText === 'Last') {
-          sortBy = this.sortFilters.LAST_NAME;
+        if (primaryFilterIs === filters.LAST_NAME) {
+          sortBy = [filters.LAST_NAME, filters.FIRST_NAME, filters.DEPARTMENT];
         }
-        if (e.target.innerText === 'Department') {
-          sortBy = this.sortFilters.DEPARTMENT;
+        if (primaryFilterIs === filters.DEPARTMENT) {
+          sortBy = [filters.DEPARTMENT, filters.FIRST_NAME, filters.LAST_NAME];
         }
 
-        this.expandedCardIds = [];
-        this.sortUsers(sortBy);
+        this.collapseAllExpandedCards();
+        let sorted = Database.getUsersSortedBy(sortBy);
+        // this.users = this.sortDirectionIsReversed ? sorted.reverse() : sorted;
+        this.users = sorted;
       }
 
       setSortDirection(e) {
         let reverseAlphabetical = e.target.innerText === 'Z-A';
         this.sortDirectionIsReversed = reverseAlphabetical;
 
-        this.sortUsers(this.currentSortFilter);
-      }
-
-      sortUsers(primarySortFilter) {
-        let sorted;
-        let sortBy = this.sortFilters;
-
-        if (primarySortFilter === sortBy.FIRST_NAME) {
-          sorted = SortUtil.sortUsersBy(this.users, sortBy.FIRST_NAME, sortBy.LAST_NAME, sortBy.DEPARTMENT);
-        }
-        if (primarySortFilter === sortBy.LAST_NAME) {
-          sorted = SortUtil.sortUsersBy(this.users, sortBy.LAST_NAME, sortBy.FIRST_NAME, sortBy.DEPARTMENT);
-        }
-        if (primarySortFilter === sortBy.DEPARTMENT) {
-          sorted = SortUtil.sortUsersBy(this.users, sortBy.DEPARTMENT, sortBy.LAST_NAME, sortBy.FIRST_NAME);
-        }
-
-        this.currentSortFilter = primarySortFilter;
-
-        this.users = [];
-        this.users = this.sortDirectionIsReversed ? sorted.reverse() : sorted;
+        this.sortUsers(this.currentSortFilters);
       }
 
       addIdToExpandedList(id) {
@@ -393,6 +378,7 @@
       }
 
       isFirstWithNewLetter(users, index) {
+
         if (users.length) {
 
           let isFirstUserInSortedList = index === 0;
@@ -402,7 +388,7 @@
 
           let previousUser = users[index - 1];
           let currentUser = users[index];
-          let category = this.currentSortFilter || this.sortFilters.LAST_NAME;
+          let category = this.currentSortFilters[0] || this.sortFilters.LAST_NAME;
 
           if (previousUser && currentUser) {
             let previousUserCategoryLetter = previousUser[category].slice(0, 1);
@@ -413,13 +399,16 @@
         }
       }
 
-      sortFilterIs(expectedSortFilter, currentSortFilter) {
-        return expectedSortFilter === currentSortFilter;
+      sortFilterIs(expectedSortFilter, currentSortFilters) {
+        if (currentSortFilters.length) {
+
+          return expectedSortFilter === currentSortFilters[0];
+        }
       }
 
       setNewGroupHeader(user, index, users) {
 
-        let category = this.currentSortFilter;
+        let category = this.currentSortFilters[0];
         let categoryIsDepartment = category === this.sortFilters.DEPARTMENT;
         let firstLetterOfCategory = user[category].slice(0, 1);
 
@@ -430,7 +419,6 @@
         if (!categoryIsDepartment) {
           return `${firstLetterOfCategory}`;
         }
-
       }
     }
 

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -215,7 +215,7 @@
             </div>
           </template>
           <template is="dom-repeat" items="[[users]]" as="user">
-            <template is="dom-if" if="[[isFirstWithNewLetter(users, index)]]">
+            <template is="dom-if" if="[[setDisplayOfSortSection(users, index)]]">
               <div class="category-header">
                 <div class="category-text">[[setNewGroupHeader(user, index, users)]]</div>
               </div>
@@ -375,25 +375,28 @@
         return isExpanded;
       }
 
-      isFirstWithNewLetter(users, index) {
-
+      setDisplayOfSortSection(users, index) {
         if (users.length) {
 
           let isFirstUserInSortedList = index === 0;
+
           if (isFirstUserInSortedList) {
             return true;
           }
 
           let previousUser = users[index - 1];
           let currentUser = users[index];
-          let category = this.currentSortFilter || this.sortFilters.LAST_NAME;
+          let defaultSort = this.sortFilters.LAST_NAME;
+          let category = this.currentSortFilter || defaultSort;
 
           if (previousUser && currentUser) {
             let previousUserCategoryLetter = previousUser[category].slice(0, 1);
             let currentUserCategoryLetter = currentUser[category].slice(0, 1);
+            let isFirstInNewSortSection = previousUserCategoryLetter !== currentUserCategoryLetter;
 
-            return previousUserCategoryLetter !== currentUserCategoryLetter;
+            return isFirstInNewSortSection;
           }
+
         }
       }
 

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -316,9 +316,7 @@
         }
 
         this.collapseAllExpandedCards();
-        let sorted = Database.getUsersSortedBy(sortBy);
-        this.users = this.sortDirectionIsReversed ? sorted.reverse() : sorted;
-        this.users = sorted;
+        this.users = this.sortDirectionIsReversed ? Database.getUsersSortedBy(sortBy).reverse() : Database.getUsersSortedBy(sortBy);
       }
 
       sortByDirection(e) {

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -174,17 +174,17 @@
               <hr>
               <div class="dropdown-options">
                 <li id="last" on-click="sortUsers">Last
-                  <template is="dom-if" if="[[primarySortFilterIs(sortFilters.LAST_NAME, currentSortFilters)]]">
+                  <template is="dom-if" if="[[sortFilterIs(sortFilters.LAST_NAME, currentSortFilter)]]">
                     ✓
                   </template>
                 </li>
                 <li id="first" on-click="sortUsers">First
-                  <template is="dom-if" if="[[primarySortFilterIs(sortFilters.FIRST_NAME, currentSortFilters)]]">
+                  <template is="dom-if" if="[[sortFilterIs(sortFilters.FIRST_NAME, currentSortFilter)]]">
                     ✓
                   </template>
                 </li>
                 <li id="department" on-click="sortUsers">Department
-                  <template is="dom-if" if="[[primarySortFilterIs(sortFilters.DEPARTMENT, currentSortFilters)]]">
+                  <template is="dom-if" if="[[sortFilterIs(sortFilters.DEPARTMENT, currentSortFilter)]]">
                     ✓
                   </template>
                 </li>
@@ -256,7 +256,7 @@
               };
             }
           },
-          currentSortFilters: {
+          currentSortFilter: {
             type: String,
             value: 'last'
           },
@@ -305,13 +305,13 @@
         let primaryFilterIs = isDropdownSelection ? sortFilter.target.id : sortFilter;
         this.currentSortFilter = primaryFilterIs;
 
-        if (primaryFilterIs === filters.FIRST_NAME) {
-          sortBy = [filters.FIRST_NAME, filters.LAST_NAME, filters.DEPARTMENT];
-        }
         if (primaryFilterIs === filters.LAST_NAME) {
           sortBy = [filters.LAST_NAME, filters.FIRST_NAME, filters.DEPARTMENT];
         }
-        if (primaryFilterIs === filters.DEPARTMENT) {
+        else if (primaryFilterIs === filters.FIRST_NAME) {
+          sortBy = [filters.FIRST_NAME, filters.LAST_NAME, filters.DEPARTMENT];
+        }
+        else if (primaryFilterIs === filters.DEPARTMENT) {
           sortBy = [filters.DEPARTMENT, filters.FIRST_NAME, filters.LAST_NAME];
         }
 
@@ -397,11 +397,8 @@
         }
       }
 
-      sortFilterIs(expectedSortFilter, currentSortFilters) {
-        if (currentSortFilters.length) {
-
-          return expectedSortFilter === currentSortFilters[0];
-        }
+      sortFilterIs(expectedSortFilter, currentSortFilter) {
+        return expectedSortFilter === currentSortFilter;
       }
 
       setNewGroupHeader(user, index, users) {

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -194,12 +194,12 @@
               <div class="dropdown-header">Sort Direction:</div>
               <hr>
               <div class="sort-direction-options dropdown-options">
-                <li on-click="setSortDirection">A-Z
+                <li id="alphabetical" on-click="sortByDirection">A-Z
                   <template is="dom-if" if="[[!sortDirectionIsReversed]]">
                     ✓
                   </template>
                 </li>
-                <li on-click="setSortDirection">Z-A
+                <li id="reversed" on-click="sortByDirection">Z-A
                   <template is="dom-if" if="[[sortDirectionIsReversed]]">
                     ✓
                   </template>
@@ -257,8 +257,8 @@
             }
           },
           currentSortFilters: {
-            type: Array,
-            value: ['last']
+            type: String,
+            value: 'last'
           },
           sortDirectionIsReversed: {
             type: Boolean,
@@ -279,8 +279,7 @@
         });
 
         document.addEventListener('databaseUpdated', e => {
-          this.users = Database.getUsers();
-          this.sortUsers(this.currentSortFilters);
+          this.sortUsers(this.currentSortFilter);
           this.popupMessage(e.detail.message);
 
           if (e.detail.message === 'Edit Save') {
@@ -301,9 +300,10 @@
 
       sortUsers(sortFilter) {
         let filters = this.sortFilters;
-        let isDropdownSelection = sortFilter.target.id
+        let isDropdownSelection = Boolean(sortFilter.target);
         let sortBy;
         let primaryFilterIs = isDropdownSelection ? sortFilter.target.id : sortFilter;
+        this.currentSortFilter = primaryFilterIs;
 
         if (primaryFilterIs === filters.FIRST_NAME) {
           sortBy = [filters.FIRST_NAME, filters.LAST_NAME, filters.DEPARTMENT];
@@ -317,15 +317,13 @@
 
         this.collapseAllExpandedCards();
         let sorted = Database.getUsersSortedBy(sortBy);
-        // this.users = this.sortDirectionIsReversed ? sorted.reverse() : sorted;
+        this.users = this.sortDirectionIsReversed ? sorted.reverse() : sorted;
         this.users = sorted;
       }
 
-      setSortDirection(e) {
-        let reverseAlphabetical = e.target.innerText === 'Z-A';
-        this.sortDirectionIsReversed = reverseAlphabetical;
-
-        this.sortUsers(this.currentSortFilters);
+      sortByDirection(e) {
+        this.sortDirectionIsReversed = e.target.id === 'reversed';
+        this.sortUsers(this.currentSortFilter);
       }
 
       addIdToExpandedList(id) {
@@ -388,7 +386,7 @@
 
           let previousUser = users[index - 1];
           let currentUser = users[index];
-          let category = this.currentSortFilters[0] || this.sortFilters.LAST_NAME;
+          let category = this.currentSortFilter || this.sortFilters.LAST_NAME;
 
           if (previousUser && currentUser) {
             let previousUserCategoryLetter = previousUser[category].slice(0, 1);
@@ -408,7 +406,8 @@
 
       setNewGroupHeader(user, index, users) {
 
-        let category = this.currentSortFilters[0];
+        let category = this.currentSortFilter || this.sortFilters.LAST_NAME;
+
         let categoryIsDepartment = category === this.sortFilters.DEPARTMENT;
         let firstLetterOfCategory = user[category].slice(0, 1);
 

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -194,12 +194,12 @@
               <div class="dropdown-header">Sort Direction:</div>
               <hr>
               <div class="sort-direction-options dropdown-options">
-                <li id="alphabetical" on-click="sortByDirection">A-Z
+                <li id="sortAlphabetical" on-click="sortByDirection">A-Z
                   <template is="dom-if" if="[[!sortDirectionIsReversed]]">
                     ✓
                   </template>
                 </li>
-                <li id="reversed" on-click="sortByDirection">Z-A
+                <li id="sortReversedAlphabetical" on-click="sortByDirection">Z-A
                   <template is="dom-if" if="[[sortDirectionIsReversed]]">
                     ✓
                   </template>
@@ -322,7 +322,7 @@
       }
 
       sortByDirection(e) {
-        this.sortDirectionIsReversed = e.target.id === 'reversed';
+        this.sortDirectionIsReversed = e.target.id === 'sortReversedAlphabetical';
         this.sortUsers(this.currentSortFilter);
       }
 

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -232,7 +232,6 @@
 
     import { Element as PolymerElement } from '@banno/polymer/polymer-element.js'; // eslint-disable-line no-unused-vars
     import Database from './../api/user-database.js';
-    import { SortUtil } from './../api/utils.js';
 
     class UserListElement extends PolymerElement {
       static get is() { return 'user-list'; }
@@ -308,15 +307,16 @@
         if (primaryFilterIs === filters.LAST_NAME) {
           sortBy = [filters.LAST_NAME, filters.FIRST_NAME, filters.DEPARTMENT];
         }
-        else if (primaryFilterIs === filters.FIRST_NAME) {
+        if (primaryFilterIs === filters.FIRST_NAME) {
           sortBy = [filters.FIRST_NAME, filters.LAST_NAME, filters.DEPARTMENT];
         }
-        else if (primaryFilterIs === filters.DEPARTMENT) {
+        if (primaryFilterIs === filters.DEPARTMENT) {
           sortBy = [filters.DEPARTMENT, filters.FIRST_NAME, filters.LAST_NAME];
         }
 
         this.collapseAllExpandedCards();
-        this.users = this.sortDirectionIsReversed ? Database.getUsersSortedBy(sortBy).reverse() : Database.getUsersSortedBy(sortBy);
+        let reversedSort = this.sortDirectionIsReversed;
+        this.users = reversedSort ? Database.getUsersSortedBy(sortBy).reverse() : Database.getUsersSortedBy(sortBy);
       }
 
       sortByDirection(e) {


### PR DESCRIPTION
## What It Does

This moves all the sorting of users into `Database.getUsersSortedBy()` in the database API

I hit a wall with getting the dom-repeat to refresh. Bryan Coulter suggested moving the sorting into the Database, both to solve the problem, and for cleaner code and more flexibility for later use of the Database.

- Sort functions are in Database API
- user-list.html now gets sorted users rather than sorting users itself.

## How To Test

- Sort users by each category
- Sort by alphabetical direction
- Set sort parameters and create or edit a new user (should be placed in proper sort category)
- Create or edit a user into a category that doesn't exist (should show header for that new category immediately)

## Notes/Caveats

There are some issues with the expanded/collapsed display of user cards that are being worked on in another branch atm

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [x] Updated the docs, if necessary
- [x] Included the appropriate labels
- [ ] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)

Browsers tested:
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] ~Edge~
- [ ] ~Internet Explorer~

## Dependencies

None
