### PR TITLE
Sort Users Mini Project: Collapse Cards On Edit-Save and Sort

### DIFF
--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -332,8 +332,6 @@
       }
 
       resetExpandedCardIds(reset) {
-        console.log(reset);
-
         if (reset) {
           this.expandedCardIds = [];
         } else {
@@ -400,7 +398,8 @@
         let compareWholeWord = previousUser[sortCategory] !== currentUser[sortCategory];
         let compareFirstLetter = previousUser[sortCategory].slice(0, 1) !== currentUser[sortCategory].slice(0, 1);
 
-        let insertNewCategoryHeader = (sortCategory === this.sortFilters.DEPARTMENT) ? compareWholeWord : compareFirstLetter;
+        let categoryIsDepartment = sortCategory === this.sortFilters.DEPARTMENT;
+        let insertNewCategoryHeader = categoryIsDepartment ? compareWholeWord : compareFirstLetter;
 
         return insertNewCategoryHeader;
       }

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -173,17 +173,17 @@
               </div>
               <hr>
               <div class="dropdown-options">
-                <li id="last" on-click="setSortedUsersBy">Last
+                <li id="last" on-click="dropdownSort">Last
                   <template is="dom-if" if="[[sortFilterIs(sortFilters.LAST_NAME, currentSortFilter)]]">
                     ✓
                   </template>
                 </li>
-                <li id="first" on-click="setSortedUsersBy">First
+                <li id="first" on-click="dropdownSort">First
                   <template is="dom-if" if="[[sortFilterIs(sortFilters.FIRST_NAME, currentSortFilter)]]">
                     ✓
                   </template>
                 </li>
-                <li id="department" on-click="setSortedUsersBy">Department
+                <li id="department" on-click="dropdownSort">Department
                   <template is="dom-if" if="[[sortFilterIs(sortFilters.DEPARTMENT, currentSortFilter)]]">
                     ✓
                   </template>
@@ -281,7 +281,7 @@
         document.addEventListener('databaseUpdated', e => {
           this.setSortedUsersBy(this.currentSortFilter);
           this.popupMessage(e.detail.message);
-          this.resetExpandedCardIds(message === 'Edit Save');
+          this.resetExpandedCardIds(e.detail.message === 'Edit Save');
         });
 
         document.addEventListener('editInProgress', e => {
@@ -295,13 +295,16 @@
         });
       }
 
-      setSortedUsersBy(sortFilter) {
-        let isDropdownSelection = Boolean(sortFilter.target);
-        let filterFirstBy = isDropdownSelection ? sortFilter.target.id : sortFilter;
-        this.currentSortFilter = filterFirstBy;
+      dropdownSort(e) {
+        this.resetExpandedCardIds(true);
+        this.setSortedUsersBy(e.target.id);
+      }
+
+      setSortedUsersBy(filterFirstBy) {
 
         let sortBy = this.getSortArray(filterFirstBy);
 
+        this.currentSortFilter = filterFirstBy;
         let reversedSort = this.sortDirectionIsReversed;
         this.users = reversedSort ? Database.getUsersSortedBy(sortBy).reverse() : Database.getUsersSortedBy(sortBy);
       }
@@ -325,15 +328,13 @@
       sortByDirection(e) {
         this.sortDirectionIsReversed = e.target.id === 'sortReversedAlphabetical';
         this.setSortedUsersBy(this.currentSortFilter);
+        this.resetExpandedCardIds(true);
       }
 
-      resetExpandedCardIds(bool) {
-
-        if (bool) {
+      resetExpandedCardIds(reset) {
+        if (reset) {
           this.expandedCardIds = [];
-        }
-
-        if (bool) {
+        } else {
           this.expandedCardIds = this.expandedCardIds;
         }
       }

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -281,7 +281,7 @@
         document.addEventListener('databaseUpdated', e => {
           this.setSortedUsersBy(this.currentSortFilter);
           this.popupMessage(e.detail.message);
-          this.updateExpandedIds(e.detail.message)
+          this.resetExpandedCardIds(message === 'Edit Save');
         });
 
         document.addEventListener('editInProgress', e => {
@@ -296,28 +296,30 @@
       }
 
       setSortedUsersBy(sortFilter) {
-        let filters = this.sortFilters;
         let isDropdownSelection = Boolean(sortFilter.target);
-        let sortBy;
-        let primaryFilterIs = isDropdownSelection ? sortFilter.target.id : sortFilter;
-        this.currentSortFilter = primaryFilterIs;
+        let filterFirstBy = isDropdownSelection ? sortFilter.target.id : sortFilter;
+        this.currentSortFilter = filterFirstBy;
 
-        if (primaryFilterIs === filters.LAST_NAME) {
-          sortBy = [filters.LAST_NAME, filters.FIRST_NAME, filters.DEPARTMENT];
-        }
-        if (primaryFilterIs === filters.FIRST_NAME) {
-          sortBy = [filters.FIRST_NAME, filters.LAST_NAME, filters.DEPARTMENT];
-        }
-        if (primaryFilterIs === filters.DEPARTMENT) {
-          sortBy = [filters.DEPARTMENT, filters.FIRST_NAME, filters.LAST_NAME];
-        }
-
-        if (isDropdownSelection) {
-          this.updateExpandedIds("Dropdown Sort");
-        }
+        let sortBy = this.getSortArray(filterFirstBy);
 
         let reversedSort = this.sortDirectionIsReversed;
         this.users = reversedSort ? Database.getUsersSortedBy(sortBy).reverse() : Database.getUsersSortedBy(sortBy);
+      }
+
+      getSortArray(filterFirstBy) {
+        let firstName = this.sortFilters.FIRST_NAME;
+        let lastName = this.sortFilters.LAST_NAME;
+        let department = this.sortFilters.DEPARTMENT;
+
+        if (filterFirstBy === lastName) {
+          return [lastName, firstName, department];
+        }
+        if (filterFirstBy === firstName) {
+          return [firstName, lastName, department];
+        }
+        if (filterFirstBy === department) {
+          return [department, firstName, lastName];
+        }
       }
 
       sortByDirection(e) {
@@ -325,12 +327,14 @@
         this.setSortedUsersBy(this.currentSortFilter);
       }
 
-      updateExpandedIds(action) {
-        let isSaveEdit = action === "Save Edit";
-        let isDropdownSort = action === "Dropdown Sort";
+      resetExpandedCardIds(bool) {
 
-        if (isSaveEdit || isDropdownSort) {
+        if (bool) {
           this.expandedCardIds = [];
+        }
+
+        if (bool) {
+          this.expandedCardIds = this.expandedCardIds;
         }
       }
 

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -220,7 +220,8 @@
                 <div class="category-text">[[setNewGroupHeader(user, index, users)]]</div>
               </div>
             </template>
-            <user-component edit-open="[[editInProgress]]" is-expanded="[[isUserCardDisplayExpanded(user.id, users)]]" user-to-display="[[user]]"></user-component>
+            <user-component edit-open="[[editInProgress]]" is-expanded="[[isUserCardDisplayExpanded(user.id, users, expandedCardIds)]]"
+              user-to-display="[[user]]"></user-component>
           </template>
         </div>
       </div>
@@ -280,10 +281,7 @@
         document.addEventListener('databaseUpdated', e => {
           this.setSortedUsersBy(this.currentSortFilter);
           this.popupMessage(e.detail.message);
-
-          if (e.detail.message === 'Edit Save') {
-            this.collapseAllExpandedCards();
-          }
+          this.updateExpandedIds(e.detail.message)
         });
 
         document.addEventListener('editInProgress', e => {
@@ -314,7 +312,10 @@
           sortBy = [filters.DEPARTMENT, filters.FIRST_NAME, filters.LAST_NAME];
         }
 
-        this.collapseAllExpandedCards();
+        if (isDropdownSelection) {
+          this.updateExpandedIds("Dropdown Sort");
+        }
+
         let reversedSort = this.sortDirectionIsReversed;
         this.users = reversedSort ? Database.getUsersSortedBy(sortBy).reverse() : Database.getUsersSortedBy(sortBy);
       }
@@ -322,6 +323,15 @@
       sortByDirection(e) {
         this.sortDirectionIsReversed = e.target.id === 'sortReversedAlphabetical';
         this.setSortedUsersBy(this.currentSortFilter);
+      }
+
+      updateExpandedIds(action) {
+        let isSaveEdit = action === "Save Edit";
+        let isDropdownSort = action === "Dropdown Sort";
+
+        if (isSaveEdit || isDropdownSort) {
+          this.expandedCardIds = [];
+        }
       }
 
       addIdToExpandedList(id) {
@@ -355,10 +365,6 @@
         window.setTimeout(() => {
           messageBox.className = 'message-box';
         }, animationTime);
-      }
-
-      collapseAllExpandedCards() {
-        this.expandedCardIds = [];
       }
 
       isUserCardDisplayExpanded(userId) {

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -296,8 +296,8 @@
       }
 
       dropdownSort(e) {
-        this.resetExpandedCardIds(true);
         this.setSortedUsersBy(e.target.id);
+        this.resetExpandedCardIds(true);
       }
 
       setSortedUsersBy(filterFirstBy) {

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -215,7 +215,7 @@
             </div>
           </template>
           <template is="dom-repeat" items="[[users]]" as="user">
-            <template is="dom-if" if="[[setDisplayOfSortSection(users, index)]]">
+            <template is="dom-if" if="[[setDisplayOfSortSection(users, index, currentSortFilter)]]">
               <div class="category-header">
                 <div class="category-text">[[setNewGroupHeader(user, index, users)]]</div>
               </div>
@@ -332,6 +332,8 @@
       }
 
       resetExpandedCardIds(reset) {
+        console.log(reset);
+
         if (reset) {
           this.expandedCardIds = [];
         } else {
@@ -385,28 +387,22 @@
       }
 
       setDisplayOfSortSection(users, index) {
-        if (users.length) {
+        let previousUser = users[index - 1];
+        let currentUser = users[index];
+        let sortCategory = this.currentSortFilter || this.sortFilters.LAST_NAME;
 
-          let isFirstUserInSortedList = index === 0;
+        let isFirstUserInSortedList = !previousUser;
 
-          if (isFirstUserInSortedList) {
-            return true;
-          }
-
-          let previousUser = users[index - 1];
-          let currentUser = users[index];
-          let defaultSort = this.sortFilters.LAST_NAME;
-          let category = this.currentSortFilter || defaultSort;
-
-          if (previousUser && currentUser) {
-            let previousUserCategoryLetter = previousUser[category].slice(0, 1);
-            let currentUserCategoryLetter = currentUser[category].slice(0, 1);
-            let isFirstInNewSortSection = previousUserCategoryLetter !== currentUserCategoryLetter;
-
-            return isFirstInNewSortSection;
-          }
-
+        if (isFirstUserInSortedList) {
+          return true;
         }
+
+        let compareWholeWord = previousUser[sortCategory] !== currentUser[sortCategory];
+        let compareFirstLetter = previousUser[sortCategory].slice(0, 1) !== currentUser[sortCategory].slice(0, 1);
+
+        let insertNewCategoryHeader = (sortCategory === this.sortFilters.DEPARTMENT) ? compareWholeWord : compareFirstLetter;
+
+        return insertNewCategoryHeader;
       }
 
       sortFilterIs(expectedSortFilter, currentSortFilter) {


### PR DESCRIPTION
## What It Does

Expanded user cards now collapse on Edit-Save and Sort. 

Random expanded cards moving around in the list when sorted in different ways was a little janky. 
This does still keep user cards expanded when you delete a user or save a new user.

I created a `resetExpandedCardIds(bool)` function that either clears out the userIds array or prompts the function that triggers the `<user-component is-expanded=[[isUserCardDisplayExpanded]]`> attribute.

This closes #128 

## How To Test

Expand a users details then:

These actions should not collapse the card:

  - Save New User
  - Delete User 

These actions should collapse the card:

  - Save User Edit
  - Sort users or change sort direction

## Notes/Caveats

There is a bug in firefox that user details are displayed as editable inputs that you can put a cursor in. It doesn't let you edit but it's still a problem I'll need to resolve. I'll open a new issue for this.

- [x] Issue Opened

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [x] Updated the docs, if necessary
- [x] Included the appropriate labels
- [x] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)
- [x] ARE YOU MERGING INTO THE CORRECT BRANCH!?

Browsers tested:
- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] ~Edge~
- [ ] ~Internet Explorer~

## Dependencies

None
