### PR TITLE
Sort Users Mini: Firefox readonly Bug Fix

### DIFF
--- a/src/user-component/user-component.css
+++ b/src/user-component/user-component.css
@@ -42,7 +42,11 @@ input:focus {
 }
 
 input:read-only {
-  border: none;
+  border-bottom: none;
+}
+
+input:-moz-read-only {
+  border-bottom: none;
 }
 
 input:-webkit-autofill {


### PR DESCRIPTION
## What It Does

Adds css selector specifically for Firefox readonly

## How To Test

User details should appear without bottom border.

## Notes/Caveats

Firefox still allows a cursor to be displayed when input is clicked. I don't know whether to fix this or not.

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [ ] Updated the docs, if necessary
- [x] Included the appropriate labels
- [ ] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)
- [x] ARE YOU MERGING INTO THE CORRECT BRANCH!?

Browsers tested:
- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] ~Edge~
- [ ] ~Internet Explorer~

## Dependencies

None
