### PR TITLE
Intern Onboarding Project: User Component Code Splitting

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "## Description This app allows you to create and edit user profiles, each of which have an ID, Name, Number, and Email Address.",
   "main": "index.js",
   "scripts": {
+    "prestart": "ux-lint --extend .lintrc.json src/*/*.html",
     "build": "webpack",
     "release": "webpack --env.release",
     "start": "webpack-dev-server",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,6 @@
   "description": "## Description This app allows you to create and edit user profiles, each of which have an ID, Name, Number, and Email Address.",
   "main": "index.js",
   "scripts": {
-    "prestart": "ux-lint --extend .lintrc.json src/*/*.html",
     "build": "webpack",
     "release": "webpack --env.release",
     "start": "webpack-dev-server",

--- a/src/api/user-database.js
+++ b/src/api/user-database.js
@@ -1,4 +1,4 @@
-class Database {
+export class Database {
   static getUsers() {
     return JSON.parse(localStorage.getItem("onboardProjectUsers")) || [];
   }
@@ -131,5 +131,3 @@ class Database {
     return idAlreadyExists ? this.createNewUserId() : id;
   }
 }
-
-module.exports = Database;

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -1,7 +1,4 @@
 export class ValidateUtil {
-  static helloKitty() {
-    return "kitty";
-  }
   static formatPhoneNumber(phoneNumber) {
     let domesticPhoneLength = 10;
     let isInternationalNumber = phoneNumber.length > domesticPhoneLength;

--- a/src/api/utils.js
+++ b/src/api/utils.js
@@ -1,4 +1,7 @@
-class ValidateUtil {
+export class ValidateUtil {
+  static helloKitty() {
+    return "kitty";
+  }
   static formatPhoneNumber(phoneNumber) {
     let domesticPhoneLength = 10;
     let isInternationalNumber = phoneNumber.length > domesticPhoneLength;
@@ -62,4 +65,4 @@ class ValidateUtil {
   }
 }
 
-module.exports = ValidateUtil;
+// module.exports = ValidateUtil;

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -516,10 +516,10 @@
       }
 
       formatUserData(newUser) {
-        let user = Boolean(newUser) ? newUser : Object.assign({}, this.user);
+        let user = newUser ? newUser : Object.assign({}, this.user);
 
         if (!user.phone.match(/\D/)) {
-          user.phone = ValidateUtil.formatPhoneNumber(user.phone);
+          user.phone = ValidateUtil.formatPhoneNumber(user.phone); // eslint-disable-line no-undef
         }
 
         this.user = user;
@@ -531,9 +531,9 @@
         let user = Object.assign({}, this.user);
 
         if (this.isMode(this.modes.CREATE_NEW)) {
-          Database.saveUser(user);
+          Database.saveUser(user); // eslint-disable-line no-undef
         } else {
-          Database.editUser(user);
+          Database.editUser(user); // eslint-disable-line no-undef
         }
 
         this.resetFormState();
@@ -542,7 +542,7 @@
 
       delete(e) {
         e.preventDefault();
-        Database.deleteUser(this.user);
+        Database.deleteUser(this.user); // eslint-disable-line no-undef
         this.editInProgress(false);
         this.mode = this.modes.DISPLAY;
         this.toggleEditableInputs();
@@ -571,7 +571,9 @@
         if (!this.firstLoad) {
           let editOpenAndNewUser = this.editOpen && this.isMode(this.modes.CREATE_NEW);
           let emptyFields = !this.areFieldsFilled();
+          // eslint-disable-next-line no-undef
           let improperPhoneFormat = !ValidateUtil.checkPhoneInput(this.user.phone);
+          // eslint-disable-next-line no-undef
           let improperEmailFormat = !ValidateUtil.checkEmailInput(this.user.email);
 
           this.disableSave = editOpenAndNewUser || emptyFields || improperPhoneFormat || improperEmailFormat;
@@ -583,7 +585,9 @@
         let emailInProgress = this.user.email;
         let phoneInProgress = this.user.phone;
 
+        // eslint-disable-next-line no-undef
         this.displayEmailWarning = emailInProgress && !ValidateUtil.checkEmailInput(this.user.email);
+        // eslint-disable-next-line no-undef
         this.displayPhoneWarning = phoneInProgress && !ValidateUtil.checkPhoneInput(this.user.phone);
         this.displayOpenEditMessage = isNewUserCard && this.editOpen;
 

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -489,7 +489,9 @@
             window.ValidateUtil = require('./../api/utils').ValidateUtil;
             window.Database = require('./../api/user-database').Database;
           },
-          () => { },
+          (error) => {
+            return error;
+          },
           'Classes'
         ).then(() => {
           this.formatUserData();

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -473,7 +473,11 @@
       ready() {
         super.ready();
         this.firstLoad = false;
+        this.importValidateUtil();
+        this.importDatabase();
+      }
 
+      importValidateUtil() {
         require.ensure(
           ['./../api/utils'],
           (require) => {
@@ -484,7 +488,19 @@
         ).then(() => {
           this.formatUserData();
         });
+      }
 
+      importDatabase() {
+        require.ensure(
+          ['./../api/user-database'],
+          (require) => {
+            window.Database = require('./../api/user-database').Database;
+          },
+          () => { },
+          'ValidateUtil'
+        ).then(() => {
+          this.formatUserData();
+        });
       }
 
       initCardState() {
@@ -522,7 +538,6 @@
 
         this.resetFormState();
         this.editInProgress(false);
-
       }
 
       delete(e) {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -406,7 +406,8 @@
             }
           },
           userToDisplay: {
-            type: Object
+            type: Object,
+            observer: 'userUpdated'
           },
           user: {
             type: Object,
@@ -471,10 +472,6 @@
       connectedCallback() {
         super.connectedCallback();
         this.initCardState();
-
-        // document.addEventListener('databaseUpdated', (e) => {
-        //   this.formatUserData();
-        // });
       }
 
       ready() {
@@ -508,6 +505,16 @@
         }
       }
 
+      userUpdated(newUser) {
+        if (this.user.id) {
+          if (!newUser.phone.match(/\D/)) {
+            newUser.phone = ValidateUtil.formatPhoneNumber(newUser.phone);
+          }
+        }
+        this.user = newUser;
+
+      }
+
       formatUserData() {
         if (!this.firstLoad && this.user) {
 
@@ -518,7 +525,6 @@
             user.phone = ValidateUtil.formatPhoneNumber(user.phone);
           }
           this.user = user;
-
         }
       }
 
@@ -535,7 +541,6 @@
 
         this.resetFormState();
         this.editInProgress(false);
-        this.formatUserData();
       }
 
       delete(e) {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -359,7 +359,7 @@
       </div>
       <footer class="card_footer">
         <template is="dom-if" if="[[isMode(modes.DISPLAY, mode)]]">
-          <div id="detailsButton" on-click="toggleClicked" class="expand-details-clickable">
+          <div id="detailsButton" on-click="toggleDetailsVisibility" class="expand-details-clickable">
             <template is="dom-if" if="[[detailsArrowIconDown]]">
               <jha-drop-arrow-icon></jha-drop-arrow-icon>
             </template>
@@ -455,11 +455,6 @@
             type: Boolean,
             observer: 'setUserDetailsDisplay'
           },
-          // passed in from parent of user-component
-          userToDisplay: {
-            type: Object,
-            observer: 'formatIncomingUserData'
-          },
           userCardClass: {
             type: String,
             value: 'default-card collapse-new-user'
@@ -477,8 +472,19 @@
 
       ready() {
         super.ready();
-
         this.firstLoad = false;
+
+        require.ensure(
+          ['./../api/utils'],
+          (require) => {
+            window.ValidateUtil = require('./../api/utils').ValidateUtil;
+          },
+          () => { },
+          'ValidateUtil'
+        ).then(() => {
+          this.formatUserData();
+        });
+
       }
 
       initCardState() {
@@ -492,7 +498,14 @@
         }
       }
 
-      formatIncomingUserData(user) {
+      formatUserData() {
+        let user = this.user;
+
+        if (!this.user.phone.match(/\D/)) {
+          this.user = [];
+          user.phone = ValidateUtil.formatPhoneNumber(user.phone);
+        }
+
         this.user = user;
       }
 
@@ -584,42 +597,6 @@
         });
 
         return fieldsFilled;
-      }
-
-      toggleClicked() {
-        if (!window.ValidateUtil) {
-          require.ensure(
-            ['./../api/utils'],
-            (require) => {
-              window.ValidateUtil = require('./../api/utils').ValidateUtil;
-            },
-            () => { },
-            'ValidateUtil'
-          ).then(() => {
-            if (!this.user.phone.match(/\D/)) {
-              let user = this.user;
-              this.user = [];
-              user.phone = ValidateUtil.formatPhoneNumber(user.phone);
-              this.user = user;
-            }
-
-          }).then(() => {
-
-            this.toggleDetailsVisibility();
-          });
-        } else {
-
-          if (!this.user.phone.match(/\D/)) {
-            let user = this.user;
-            this.user = [];
-            user.phone = ValidateUtil.formatPhoneNumber(user.phone);
-            this.user = user;
-          }
-
-          this.toggleDetailsVisibility();
-        }
-
-
       }
 
       toggleDetailsVisibility() {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -533,6 +533,7 @@
         if (this.isMode(this.modes.CREATE_NEW)) {
           Database.saveUser(user); // eslint-disable-line no-undef
         } else {
+          this.toggleDetailsVisibility();
           Database.editUser(user); // eslint-disable-line no-undef
         }
 

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -359,7 +359,7 @@
       </div>
       <footer class="card_footer">
         <template is="dom-if" if="[[isMode(modes.DISPLAY, mode)]]">
-          <div id="detailsButton" on-click="toggleDetailsVisibility" class="expand-details-clickable">
+          <div id="detailsButton" on-click="toggleClicked" class="expand-details-clickable">
             <template is="dom-if" if="[[detailsArrowIconDown]]">
               <jha-drop-arrow-icon></jha-drop-arrow-icon>
             </template>
@@ -373,8 +373,7 @@
   </template>
   <script type="module">
     import { Element as PolymerElement } from '@banno/polymer/polymer-element.js'; // eslint-disable-line no-unused-vars
-    import Database from './../api/user-database.js';
-    import { ValidateUtil } from './../api/utils.js';
+    // import { ValidateUtil } from './../api/utils.js';
     class UserComponentElement extends PolymerElement {
       static get is() { return 'user-component'; }
       static get properties() {
@@ -485,7 +484,6 @@
       }
 
       formatIncomingUserData(user) {
-        user.phone = ValidateUtil.formatPhoneNumber(user.phone);
         this.user = user;
       }
 
@@ -531,8 +529,8 @@
       updateDisableSaveButton() {
         let editOpenAndNewUser = this.editOpen && this.isMode(this.modes.CREATE_NEW);
         let emptyFields = !this.areFieldsFilled();
-        let improperPhoneFormat = !ValidateUtil.checkPhoneInput(this.user.phone);
-        let improperEmailFormat = !ValidateUtil.checkEmailInput(this.user.email);
+        // let improperPhoneFormat = !ValidateUtil.checkPhoneInput(this.user.phone);
+        // let improperEmailFormat = !ValidateUtil.checkEmailInput(this.user.email);
 
         this.disableSave = editOpenAndNewUser || emptyFields || improperPhoneFormat || improperEmailFormat;
       }
@@ -542,8 +540,8 @@
         let emailInProgress = this.user.email;
         let phoneInProgress = this.user.phone;
 
-        this.displayEmailWarning = emailInProgress && !ValidateUtil.checkEmailInput(this.user.email);
-        this.displayPhoneWarning = phoneInProgress && !ValidateUtil.checkPhoneInput(this.user.phone);
+        // this.displayEmailWarning = emailInProgress && !ValidateUtil.checkEmailInput(this.user.email);
+        // this.displayPhoneWarning = phoneInProgress && !ValidateUtil.checkPhoneInput(this.user.phone);
         this.displayOpenEditMessage = isNewUserCard && this.editOpen;
 
         let errorMessageDisplayed = this.displayEmailWarning || this.displayPhoneWarning || this.displayOpenEditMessage;
@@ -571,6 +569,29 @@
         });
 
         return fieldsFilled;
+      }
+
+      toggleClicked() {
+
+        if (!window.ValidateUtil) {
+          require.ensure(
+            ['./../api/utils'],
+            (require) => {
+              window.ValidateUtil = require('./../api/utils').ValidateUtil;
+            },
+            () => { },
+            'ValidateUtil'
+          );
+        }
+
+        if (!this.user.phone.match(/\D/)) {
+          let user = this.user;
+          this.user = [];
+          user.phone = ValidateUtil.formatPhoneNumber(user.phone);
+          this.user = user;
+        }
+
+        this.toggleDetailsVisibility();
       }
 
       toggleDetailsVisibility() {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -405,6 +405,9 @@
               };
             }
           },
+          userToDisplay: {
+            type: Object
+          },
           user: {
             type: Object,
             value: () => {
@@ -416,7 +419,7 @@
                 department: '',
                 id: ''
               };
-            }
+            },
           },
           disableSave: {
             type: Boolean,
@@ -468,36 +471,27 @@
       connectedCallback() {
         super.connectedCallback();
         this.initCardState();
+
+        // document.addEventListener('databaseUpdated', (e) => {
+        //   this.formatUserData();
+        // });
       }
 
       ready() {
         super.ready();
         this.firstLoad = false;
-        this.importValidateUtil();
-        this.importDatabase();
+        this.importClasses();
       }
 
-      importValidateUtil() {
+      importClasses() {
         require.ensure(
-          ['./../api/utils'],
+          ['./../api/utils', './../api/user-database'],
           (require) => {
             window.ValidateUtil = require('./../api/utils').ValidateUtil;
-          },
-          () => { },
-          'ValidateUtil'
-        ).then(() => {
-          this.formatUserData();
-        });
-      }
-
-      importDatabase() {
-        require.ensure(
-          ['./../api/user-database'],
-          (require) => {
             window.Database = require('./../api/user-database').Database;
           },
           () => { },
-          'ValidateUtil'
+          'Classes'
         ).then(() => {
           this.formatUserData();
         });
@@ -515,14 +509,17 @@
       }
 
       formatUserData() {
-        let user = this.user;
+        if (!this.firstLoad && this.user) {
 
-        if (!this.user.phone.match(/\D/)) {
+          let user = Object.assign({}, this.user);
           this.user = [];
-          user.phone = ValidateUtil.formatPhoneNumber(user.phone);
-        }
 
-        this.user = user;
+          if (!user.phone.match(/\D/)) {
+            user.phone = ValidateUtil.formatPhoneNumber(user.phone);
+          }
+          this.user = user;
+
+        }
       }
 
       save(e) {
@@ -538,6 +535,7 @@
 
         this.resetFormState();
         this.editInProgress(false);
+        this.formatUserData();
       }
 
       delete(e) {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -374,7 +374,7 @@
   <script type="module">
     import { Element as PolymerElement } from '@banno/polymer/polymer-element.js'; // eslint-disable-line no-unused-vars
     import Database from './../api/user-database.js';
-    import ValidateUtil from './../api/utils.js';
+    import { ValidateUtil } from './../api/utils.js';
     class UserComponentElement extends PolymerElement {
       static get is() { return 'user-component'; }
       static get properties() {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -463,13 +463,22 @@
           userCardClass: {
             type: String,
             value: 'default-card collapse-new-user'
+          },
+          firstLoad: {
+            type: Boolean,
+            value: true
           }
         };
       }
-
       connectedCallback() {
         super.connectedCallback();
         this.initCardState();
+      }
+
+      ready() {
+        super.ready();
+
+        this.firstLoad = false;
       }
 
       initCardState() {
@@ -517,22 +526,28 @@
       }
 
       onInputChanged() {
-        this.updateDisableSaveButton();
-        this.updateWarningMessageDisplay();
+        if (!this.firstLoad) {
+          this.updateDisableSaveButton();
+          this.updateWarningMessageDisplay();
+        }
       }
 
       onEditOpenChanged() {
-        this.updateDisableSaveButton();
-        this.updateWarningMessageDisplay();
+        if (!this.firstLoad) {
+          this.updateDisableSaveButton();
+          this.updateWarningMessageDisplay();
+        }
       }
 
       updateDisableSaveButton() {
-        let editOpenAndNewUser = this.editOpen && this.isMode(this.modes.CREATE_NEW);
-        let emptyFields = !this.areFieldsFilled();
-        // let improperPhoneFormat = !ValidateUtil.checkPhoneInput(this.user.phone);
-        // let improperEmailFormat = !ValidateUtil.checkEmailInput(this.user.email);
+        if (!this.firstLoad) {
+          let editOpenAndNewUser = this.editOpen && this.isMode(this.modes.CREATE_NEW);
+          let emptyFields = !this.areFieldsFilled();
+          let improperPhoneFormat = !ValidateUtil.checkPhoneInput(this.user.phone);
+          let improperEmailFormat = !ValidateUtil.checkEmailInput(this.user.email);
 
-        this.disableSave = editOpenAndNewUser || emptyFields || improperPhoneFormat || improperEmailFormat;
+          this.disableSave = editOpenAndNewUser || emptyFields || improperPhoneFormat || improperEmailFormat;
+        }
       }
 
       updateWarningMessageDisplay() {
@@ -540,8 +555,8 @@
         let emailInProgress = this.user.email;
         let phoneInProgress = this.user.phone;
 
-        // this.displayEmailWarning = emailInProgress && !ValidateUtil.checkEmailInput(this.user.email);
-        // this.displayPhoneWarning = phoneInProgress && !ValidateUtil.checkPhoneInput(this.user.phone);
+        this.displayEmailWarning = emailInProgress && !ValidateUtil.checkEmailInput(this.user.email);
+        this.displayPhoneWarning = phoneInProgress && !ValidateUtil.checkPhoneInput(this.user.phone);
         this.displayOpenEditMessage = isNewUserCard && this.editOpen;
 
         let errorMessageDisplayed = this.displayEmailWarning || this.displayPhoneWarning || this.displayOpenEditMessage;
@@ -572,7 +587,6 @@
       }
 
       toggleClicked() {
-
         if (!window.ValidateUtil) {
           require.ensure(
             ['./../api/utils'],
@@ -581,17 +595,31 @@
             },
             () => { },
             'ValidateUtil'
-          );
+          ).then(() => {
+            if (!this.user.phone.match(/\D/)) {
+              let user = this.user;
+              this.user = [];
+              user.phone = ValidateUtil.formatPhoneNumber(user.phone);
+              this.user = user;
+            }
+
+          }).then(() => {
+
+            this.toggleDetailsVisibility();
+          });
+        } else {
+
+          if (!this.user.phone.match(/\D/)) {
+            let user = this.user;
+            this.user = [];
+            user.phone = ValidateUtil.formatPhoneNumber(user.phone);
+            this.user = user;
+          }
+
+          this.toggleDetailsVisibility();
         }
 
-        if (!this.user.phone.match(/\D/)) {
-          let user = this.user;
-          this.user = [];
-          user.phone = ValidateUtil.formatPhoneNumber(user.phone);
-          this.user = user;
-        }
 
-        this.toggleDetailsVisibility();
       }
 
       toggleDetailsVisibility() {

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -477,7 +477,9 @@
       ready() {
         super.ready();
         this.firstLoad = false;
-        this.importClasses();
+        if (this.user.id) {
+          this.importClasses();
+        }
       }
 
       importClasses() {
@@ -507,25 +509,20 @@
 
       userUpdated(newUser) {
         if (this.user.id) {
-          if (!newUser.phone.match(/\D/)) {
-            newUser.phone = ValidateUtil.formatPhoneNumber(newUser.phone);
-          }
+          this.formatUserData(newUser);
         }
         this.user = newUser;
 
       }
 
-      formatUserData() {
-        if (!this.firstLoad && this.user) {
+      formatUserData(newUser) {
+        let user = Boolean(newUser) ? newUser : Object.assign({}, this.user);
 
-          let user = Object.assign({}, this.user);
-          this.user = [];
-
-          if (!user.phone.match(/\D/)) {
-            user.phone = ValidateUtil.formatPhoneNumber(user.phone);
-          }
-          this.user = user;
+        if (!user.phone.match(/\D/)) {
+          user.phone = ValidateUtil.formatPhoneNumber(user.phone);
         }
+
+        this.user = user;
       }
 
       save(e) {

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -221,7 +221,7 @@
               </div>
             </template>
             <user-component edit-open="[[editInProgress]]" is-expanded="[[isUserCardDisplayExpanded(user.id, users, expandedCardIds)]]"
-              user="[[user]]"></user-component>
+              user-to-display="[[user]]"></user-component>
           </template>
         </div>
       </div>

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -386,10 +386,11 @@
         let previousUser = users[index - 1];
         let currentUser = users[index];
         let sortCategory = this.currentSortFilter || this.sortFilters.LAST_NAME;
+        let isLastUser = !Boolean(users[index + 1]);
 
         let isFirstUserInSortedList = !previousUser;
 
-        if (isFirstUserInSortedList) {
+        if (isFirstUserInSortedList || isLastUser) {
           return true;
         }
 

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -145,7 +145,7 @@
         border-radius: 3px;
         box-shadow: rgba(0, 0, 0, 0.14902) 0px 1px 1px 0px, rgba(0, 0, 0, 0.09804) 0px 1px 2px 0px;
       }
-      
+
       .category-header {
         position: relative;
         margin: 50px 0px 40px 0px;
@@ -272,7 +272,7 @@
       }
       connectedCallback() {
         super.connectedCallback();
-    
+
         document.addEventListener('cancel', () => {
           this.toggleMode();
         });
@@ -300,6 +300,16 @@
       }
 
       setSortedUsersBy(filterFirstBy) {
+        require.ensure(
+          ['./../api/utils'],
+          (mod) => {
+            console.log('wow', mod);
+
+            // this.functions.ValidateUtil = require('./../api/utils').ValidateUtil;
+          },
+          () => { },
+          'ValidateUtil'
+        );
 
         let sortBy = this.getSortArray(filterFirstBy);
 

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -232,7 +232,7 @@
   <script type="module">
 
     import { Element as PolymerElement } from '@banno/polymer/polymer-element.js'; // eslint-disable-line no-unused-vars
-    import Database from './../api/user-database.js';
+    import { Database } from './../api/user-database.js';
 
     class UserListElement extends PolymerElement {
       static get is() { return 'user-list'; }
@@ -300,17 +300,6 @@
       }
 
       setSortedUsersBy(filterFirstBy) {
-        require.ensure(
-          ['./../api/utils'],
-          (mod) => {
-            console.log('wow', mod);
-
-            // this.functions.ValidateUtil = require('./../api/utils').ValidateUtil;
-          },
-          () => { },
-          'ValidateUtil'
-        );
-
         let sortBy = this.getSortArray(filterFirstBy);
 
         this.currentSortFilter = filterFirstBy;

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -221,7 +221,7 @@
               </div>
             </template>
             <user-component edit-open="[[editInProgress]]" is-expanded="[[isUserCardDisplayExpanded(user.id, users, expandedCardIds)]]"
-              user-to-display="[[user]]"></user-component>
+              user="[[user]]"></user-component>
           </template>
         </div>
       </div>

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -386,7 +386,7 @@
         let previousUser = users[index - 1];
         let currentUser = users[index];
         let sortCategory = this.currentSortFilter || this.sortFilters.LAST_NAME;
-        let isLastUser = !Boolean(users[index + 1]);
+        let isLastUser = !users[index + 1];
 
         let isFirstUserInSortedList = !previousUser;
 


### PR DESCRIPTION
## What It Does

This lazy loads ValidateUtils and Database classes during `ready()` lifecycle event.

After taking a deeper dive into webpack and discovering code splitting, I thought it might be fun to incorporate it into my project.

The path to get to require.ensure() started with webpack's dynamic import: `import(pathToFile)` which wasn't playing nice (possibly with polymer-webpack-loader.) Though I did get `import()` to work on a polymer 3 element. 

Then I found an earlier version of `import`, require.ensure(). This creates a separate hashed bundle of code during the webpack build that gets added when the code hits the require.ensure(). 

There were some tweaks I had to make to ensure ValidateUtil and Database don't get called before they are loaded, so there is some refactoring, but no user functionality was changed. 

## How To Test

Create users, edit users, delete users. Phone number should always display in proper format. User saves and deletes should still work (popup messages, persistent changes on refresh).

## Notes/Caveats

### Performance Or Lack Thereof

I fully recognize that this actually doesn't do that much:

     - Code coverage went from roughly 33.5% unused code to 32.9%. 
     - The separately bundled classes are about 2kb.

The idea here is proof of concept.

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [x] Verified the build in production(optimized) mode
- [x] Updated the docs, if necessary
- [x] Included the appropriate labels
- [x] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)
- [x] ARE YOU MERGING INTO THE CORRECT BRANCH!?

Browsers tested:

- [x] Chrome
- [x] Firefox
- [x] Safari
- [ ] Edge
- [ ] Internet Explorer

## Dependencies

None