### PR TITLE
Database Mini: Persistent Display

### DIFF
--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -219,7 +219,7 @@
                 <div class="category-text">[[setNewGroupHeader(user, index, users)]]</div>
               </div>
             </template>
-            <user-component edit-open="[[editInProgress]]" is-expanded="[[isUserCardDisplayExpanded(user.id, users, expandedCardIds)]]"
+            <user-component edit-open="[[editInProgress]]" is-expanded="[[isUserCardDisplayExpanded(user._id, users, expandedCardIds)]]"
               user-to-display="[[user]]"></user-component>
           </template>
         </div>
@@ -294,12 +294,15 @@
 
       onUsersLoaded(response) {
         this.users = response.users;
+        let isEditSave = false;
 
         if (response.message) {
           this.popupMessage(response.message);
+          const editInMessage = /edit/gi;
+          isEditSave = editInMessage.test(response.message);
         }
 
-        this.resetExpandedCardIds(response.message === 'Edit Save');
+        this.resetExpandedCardIds(isEditSave);
       }
 
       dropdownSort(e) {
@@ -379,9 +382,9 @@
 
       isUserCardDisplayExpanded(userId) {
         let isExpanded = false;
+        
         this.expandedCardIds.forEach(id => {
           if (id === userId) {
-
             isExpanded = true;
           }
         });

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -382,7 +382,6 @@
 
       isUserCardDisplayExpanded(userId) {
         let isExpanded = false;
-        
         this.expandedCardIds.forEach(id => {
           if (id === userId) {
             isExpanded = true;


### PR DESCRIPTION
## What It Does

Restores the persistent display of an expanded user card after a new card is created or an existing card is deleted.

This used to be functionality in the project that got disconnected during the course of adding the database.

#### How

- The dom-if function call was set to send user.id instead of the new user._id.
- I modified onUsersLoaded to check for `edit` in an incoming message from the `usersLoaded` event. If that's the case then it resets the user card ids. 

## How To Test

1. Open the details on one user card then:

- Create a new user
- Delete an existing user

in both of these cases the details you expanded should remain visible.

2. Open the details on one user card then:

- Save an edit on a user
- Change the sort or sort direction in some way.

in both of these cases the details you expanded should now be hidden.

## Notes/Caveats

This still leaves the display a little janky on delete as the deleted card just sits there expanded for a bit before the list resets. This gets fixed in the next PR

## Checklist

Under penalty of public shaming, I avow that I:

- [ ] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [ ] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [x] Updated the docs, if necessary
- [x] Included the appropriate labels
- [ ] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)
- [x] ARE YOU MERGING INTO THE CORRECT BRANCH!?

Browsers tested:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer

## Dependencies

- [ ] #154 
