### PR TITLE
Database Mini: Collapse On Delete

### DIFF
--- a/src/api/user-database.js
+++ b/src/api/user-database.js
@@ -1,11 +1,14 @@
-let lastSort = ["department", "firstName", "lastName"];
-let isReversedSort = false;
+let sortSettings = {
+  lastSort: ["firstName", "lastName"],
+  isReversedSort: false
+};
+
 let popupMessage = null;
 
 export class Database {
   static getUsers() {
     // priority from right to left
-    this.getUsersSortedBy(["department", "firstName", "lastName"]);
+    this.getUsersSortedBy(sortSettings.lastSort);
   }
 
   static sendUsers(users) {
@@ -34,7 +37,7 @@ export class Database {
   }
 
   static getUsersSortedBy(sortFilterArray) {
-    lastSort = sortFilterArray;
+    sortSettings.lastSort = sortFilterArray;
     let databaseUrl = `http://iop-db.herokuapp.com/users`;
     let xhr = new XMLHttpRequest();
 
@@ -62,32 +65,28 @@ export class Database {
   }
 
   static setReversedSort(bool) {
-    isReversedSort = bool;
+    sortSettings.isReversedSort = bool;
   }
 
   static fallbackFilters() {
     // priority from right to left
-    return ["department", "firstName", "lastName"];
+    return ["firstName", "lastName"];
   }
 
   static compareTwoUsers(a, b, sortFilterArray) {
     let compared = 0;
-    let reverseFirstFilterSort = Boolean(isReversedSort);
+    let primarySortFilter = sortFilterArray[sortFilterArray.length - 1];
 
     sortFilterArray.forEach(filter => {
-      if (a[filter] !== b[filter]) {
-        if (reverseFirstFilterSort) {
-          compared = a[filter] < b[filter] ? 1 : -1;
-          reverseFirstFilterSort = false;
-          return;
-        }
+      let categoryIsDifferent = a[filter] !== b[filter];
+      let reverseSort = sortSettings.isReversedSort && filter === primarySortFilter;
+      let aFirst = a[filter] > b[filter] ? 1 : -1;
+      let bFirst = a[filter] < b[filter] ? 1 : -1;
 
-        compared = a[filter] > b[filter] ? 1 : -1;
-        return;
+      if (categoryIsDifferent) {
+        compared = reverseSort ? bFirst : aFirst;
       }
-      reverseFirstFilterSort = false;
     });
-
     return compared;
   }
 
@@ -118,7 +117,7 @@ export class Database {
 
     xhr.onreadystatechange = responseText => {
       if (xhr.readyState === 4 && xhr.status === 200) {
-        this.getUsersSortedBy(lastSort);
+        this.getUsersSortedBy(sortSettings.lastSort);
       }
     };
   }

--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -532,6 +532,7 @@
 
         Database.deleteUser(this.user); // eslint-disable-line no-undef
         this.toggleEditDisplayMode();
+        this.toggleDetailsVisibility();
         this.clearInputFormatWarnings();
       }
 

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -219,7 +219,7 @@
                 <div class="category-text">[[setNewGroupHeader(user, index, users)]]</div>
               </div>
             </template>
-            <user-component edit-open="[[editInProgress]]" is-expanded="[[isUserCardDisplayExpanded(user.id, users, expandedCardIds)]]"
+            <user-component edit-open="[[editInProgress]]" is-expanded="[[isUserCardDisplayExpanded(user._id, users, expandedCardIds)]]"
               user-to-display="[[user]]"></user-component>
           </template>
         </div>
@@ -294,12 +294,15 @@
 
       onUsersLoaded(response) {
         this.users = response.users;
+        let isEditSave = false;
 
         if (response.message) {
           this.popupMessage(response.message);
+          const editInMessage = /edit/gi;
+          isEditSave = editInMessage.test(response.message);
         }
 
-        this.resetExpandedCardIds(response.message === 'Edit Save');
+        this.resetExpandedCardIds(isEditSave);
       }
 
       dropdownSort(e) {
@@ -379,9 +382,9 @@
 
       isUserCardDisplayExpanded(userId) {
         let isExpanded = false;
+        
         this.expandedCardIds.forEach(id => {
           if (id === userId) {
-
             isExpanded = true;
           }
         });

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -282,12 +282,6 @@
           this.toggleMode();
         });
 
-        document.addEventListener('databaseUpdated', e => {
-          this.setSortedUsersBy(this.currentSortCategory);
-          this.popupMessage(e.detail.message);
-          this.resetExpandedCardIds(e.detail.message === 'Edit Save');
-        });
-
         document.addEventListener('editInProgress', e => {
           this.editInProgress = e.detail;
         });

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -299,8 +299,7 @@
       }
 
       onUsersLoaded(response) {
-        let users = response.users;
-        this.users = this.sortDirectionIsReversed ? users.reverse() : users;
+        this.users = response.users;
 
         if (response.message) {
           this.popupMessage(response.message);
@@ -330,13 +329,13 @@
 
         // sort priority goes right to left
         if (sortFirstBy === lastName) {
-          return [department, firstName, lastName];
+          return [firstName, lastName];
         }
         if (sortFirstBy === firstName) {
-          return [department, lastName, firstName];
+          return [lastName, firstName];
         }
         if (sortFirstBy === department) {
-          return [lastName, firstName, department];
+          return [firstName, lastName, department];
         }
       }
 


### PR DESCRIPTION
## What It Does

Causes an animated collapse on an existing user when the card is deleted.

During the course of adding the live database, the former way of dealing with recycling issues in a dom-repeat list no longer worked. Although the persistent display of expanded id cards was fixed in #155 , when an existing user was deleted it stayed expanded and just sat there for a while then suddenly disappeared. It looked janky.


Entirely solved by adding one line to the delete function inside the user-component:

```js
  this.toggledetailsVisibility();
```

## How To Test

Delete a user, it should pleasantly collapse before disappearing.

## Notes/Caveats


## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [x] Updated the docs, if necessary
- [x] Included the appropriate labels
- [x] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)
- [x] ARE YOU MERGING INTO THE CORRECT BRANCH!?

Browsers tested:

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer

## Dependencies

- [ ] #156 
