### PR TITLE
Onboarding-Project: Service Worker Moved To Production Config

### DIFF
--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ Because of the dom-recycling feature of Polymer, the display state of each compo
 
         `$ yarn start` then open https://localhost:1820 in the browser.
 
-        This lints, builds, and serves the project using webpack-dev-server
+        This lints, builds, and serves the project using webpack-dev-server. It also includes settings defined in webpack.development.js, including the dev server settings and a source map for tracking code issues in dev-tools.
 
 #### To see a list of available scripts [or a single script]:
 
@@ -122,7 +122,7 @@ Because of the dom-recycling feature of Polymer, the display state of each compo
 
 #### To bundle the code for production. It gets built into the dist folder in the root.
 
-        `$ yarn build`
+        `$ yarn build` uses the normal webpack config, but also adds on webpack.production.js which minifies the code and generates a service worker with a list of files to be cached by the end-user.
 
 ## dependencies
 

--- a/build-tools/webpack.production.js
+++ b/build-tools/webpack.production.js
@@ -1,9 +1,11 @@
 const MinifyPlugin = require("babel-minify-webpack-plugin");
+const WorkboxPlugin = require("workbox-webpack-plugin");
 
 module.exports = () => {
   return {
     plugins: [
       new MinifyPlugin(),
+      new WorkboxPlugin.GenerateSW()
     ]
   };
 };

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -6,7 +6,6 @@ const CleanWebpackPlugin = require("clean-webpack-plugin");
 const HtmlWebPackPlugin = require("html-webpack-plugin");
 const ManifestPlugin = require("webpack-manifest-plugin");
 const manifestImport = require("./src/manifest.json");
-const WorkboxPlugin = require("workbox-webpack-plugin");
 
 const modeConfig = env => require(`./build-tools/webpack.${env}.js`)(env);
 
@@ -72,10 +71,9 @@ module.exports = env => {
         ]),
         new ManifestPlugin({
           seed: manifestImport,
-          writeToFileEmit: Boolean(env.development)
+          writeToFileEmit: Boolean(env.production)
         }),
-        new CleanWebpackPlugin(path.resolve("dist")),
-        new WorkboxPlugin.GenerateSW()
+        new CleanWebpackPlugin(path.resolve("dist"))
       ]
     },
     modeConfig(mode)


### PR DESCRIPTION
## What It Does

It moves the ` new WorkboxPlugin.GenerateSW()` to webpack.production.js

The service worker was hindering development as it was in the normal webpack config. Every time the code was updated the cache had to be cleared in the browser for testing.

I moved the appropriate plugin and required files into webpack.production.js

## How To Test

`$Yarn build` should generate a service worker in the dist folder.
Running the server (if you've cleared the cache) should not show workbox caching files.

## Notes/Caveats

There is an error being thrown because index is still looking for the service worker. I don't know if this is something that needs to be fixed (sort of like the webcomponent shims that error out).

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [x] Verified the build in production(optimized) mode
- [x] Updated the docs, if necessary
- [x] Included the appropriate labels
- [x] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)
- [x] ARE YOU MERGING INTO THE CORRECT BRANCH!?

Browsers tested:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer

## Dependencies

- [ ] any other PRs or issues that should be resolved/merged before this is merged
