### PR TITLE
Bug Fix: Enter Key Bypasses Form Validation

### DIFF
--- a/src/user-component/user-component.js
+++ b/src/user-component/user-component.js
@@ -153,6 +153,12 @@ class UserComponentElement extends PolymerElement {
   save(e) {
     e.preventDefault();
 
+    if (this.hasInvalidFormInputs()) {
+      this.updateWarningMessageDisplay();
+      this.updateDisableSaveButton();
+      return;
+    }
+
     const user = Object.assign({}, this.user);
 
     if (this.isMode(this.modes.CREATE_NEW)) {
@@ -188,17 +194,27 @@ class UserComponentElement extends PolymerElement {
     }
   }
 
-  updateDisableSaveButton() {
-    if (!this.isFirstLoad) {
-      const editOpenAndNewUser = this.editOpen && this.isMode(this.modes.CREATE_NEW);
+  hasInvalidFormInputs() {
+    const editOpenAndNewUser =
+      this.editOpen && this.isMode(this.modes.CREATE_NEW);
       const emptyFields = !this.areFieldsFilled();
       // eslint-disable-next-line no-undef
       const improperPhoneFormat = !ValidateUtil.checkPhoneInput(this.user.phone);
       // eslint-disable-next-line no-undef
       const improperEmailFormat = !ValidateUtil.checkEmailInput(this.user.email);
 
-      this.disableSave = editOpenAndNewUser || emptyFields || improperPhoneFormat || improperEmailFormat;
+    return (
+      editOpenAndNewUser ||
+      emptyFields ||
+      improperPhoneFormat ||
+      improperEmailFormat
+    );
     }
+
+  updateDisableSaveButton() {
+    if (!this.isFirstLoad) {
+      this.disableSave = this.hasInvalidFormInputs();
+  }
   }
 
   updateWarningMessageDisplay() {
@@ -226,7 +242,7 @@ class UserComponentElement extends PolymerElement {
   clearInputFormatWarnings() {
     this.setProperties({
       displayEmailWarning: false,
-      displayPhoneWarning: false,
+      displayPhoneWarning: false
     });
 
     this.resizeCardForWarningMessages(false);


### PR DESCRIPTION
## What It Does

Fixes bug that pressing enter bypasses proper form validation.

A form checker was added to the save function.

## How To Test

Improperly format email or phone number, then press enter. The warning message should be displayed and the save should not go through properly.

## Notes/Caveats

Are there remaining issues or things this PR hasn't solved yet? Are there long-term implications?

## Checklist

Under penalty of public shaming, I avow that I:

- [ ] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [ ] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [ ] Updated the docs, if necessary
- [ ] Included the appropriate labels
- [ ] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)
- [x] ARE YOU MERGING INTO THE CORRECT BRANCH!?

Browsers tested:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer

## Dependencies

- [ ] any other PRs or issues that should be resolved/merged before this is merged
