### PR TITLE
Bug Fix: Toast repeat

### DIFF
--- a/src/user-list/toast-message.html
+++ b/src/user-list/toast-message.html
@@ -72,15 +72,6 @@
           },
           addPersonIcon: {
             type: Boolean
-          },
-          icons: {
-            type: Object,
-            value: () => {
-              return {
-                ADD_PERSON_ICON: 'jha-add-person-icon',
-                CANCEL_ICON: 'jha-cancel-icon',
-              };
-            }
           }
         };
       }

--- a/src/user-list/toast-message.html
+++ b/src/user-list/toast-message.html
@@ -82,12 +82,16 @@
 
         messageBox.className = 'message-box show-message';
 
-        const isDeleteMessage = /delete/.test(message);
-        this.addPersonIcon = !isDeleteMessage;
+        this.setToastIcon(message);
 
         window.setTimeout(() => {
           messageBox.className = 'message-box';
         }, animationTime);
+      }
+
+      setToastIcon(message) {
+        const isDeleteMessage = /delete/.test(message);
+        this.addPersonIcon = !isDeleteMessage;
       }
     }
 

--- a/src/user-list/toast-message.html
+++ b/src/user-list/toast-message.html
@@ -66,15 +66,12 @@
       }
       static get properties() {
         return {
-          arrowUp: {
-            type: Boolean
-          },
           message: {
             type: String,
             observer: 'popupMessage'
           },
-          currentIcon: {
-            type: String
+          addPersonIcon: {
+            type: Boolean
           },
           icons: {
             type: Object,
@@ -86,9 +83,6 @@
             }
           }
         };
-      }
-      setIcon(icon) {
-        return icon === this.icons.ADD_PERSON_ICON;
       }
 
       popupMessage(message) {

--- a/src/user-list/toast-message.html
+++ b/src/user-list/toast-message.html
@@ -79,7 +79,7 @@
       popupMessage(message) {
         const animationTime = 3000;
         const messageBox = this.$.popupBox;
-
+        messageBox.className = 'message-box';
         messageBox.className = 'message-box show-message';
 
         this.setToastIcon(message);

--- a/src/user-list/user-list.js
+++ b/src/user-list/user-list.js
@@ -87,6 +87,8 @@ class UserListElement extends PolymerElement {
     let isEditSave = false;
 
     if (response.message) {
+      const toastReset = '';
+      this.toastMessage = toastReset;
       this.toastMessage = response.message;
       const editInMessage = /edit/gi;
       isEditSave = editInMessage.test(response.message);


### PR DESCRIPTION
## What It Does

Resets the toast message to handle a repeated message.

If you edit/save the exact same user two times in a row, it send the exact same message to the toast-message component and the observer doesn't fire. This resets that message to the toast to bypass this issue.

```js
    if (response.message) {
      const toastReset = '';
      this.toastMessage = toastReset;
      this.toastMessage = response.message;
    }
```

## How To Test

Edit then save the exact same user twice in a row (without changing their first or last name). The toast message should still appear that you've edited that user twice.

## Notes/Caveats

Are there remaining issues or things this PR hasn't solved yet? Are there long-term implications?

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [x] Updated the docs, if necessary
- [x] Included the appropriate labels
- [ ] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)
- [x] ARE YOU MERGING INTO THE CORRECT BRANCH!?

Browsers tested:

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer

## Dependencies

- [ ] any other PRs or issues that should be resolved/merged before this is merged
