### PR TITLE
Got rid of editUserHeader function

### DIFF
--- a/src/user-component/user-component.html
+++ b/src/user-component/user-component.html
@@ -173,7 +173,7 @@
           </div>
         </template>
         <template is="dom-if" if="[[isMode(modes.EDIT_USER, mode)]]">
-          <h1 class="edit-user-header">[[setEditUserHeader(user)]]</h1>
+          <h1 class="edit-user-header">Edit: [[user.lastName]], [[user.firstName]]</h1>
         </template>
         <template is="dom-if" if="[[isMode(modes.CREATE_NEW, mode)]]">
           <create-user-button add-user-icon="[[isClass(classes.COLLAPSE_NEW, userCardClass)]]" on-click="toggleNewUserFormDisplay"></create-user-button>

--- a/src/user-component/user-component.js
+++ b/src/user-component/user-component.js
@@ -291,10 +291,6 @@ class UserComponentElement extends PolymerElement {
     return arrowIsDown;
   }
 
-  setEditUserHeader() {
-    return `Edit: ${this.user.lastName}, ${this.user.firstName}`;
-  }
-
   editInProgress(bool) {
     this.dispatchEvent(new CustomEvent('editInProgress', {
       bubbles: true,


### PR DESCRIPTION
## What It Does

Changes editUser header to be data bound text rather than data-bound function

Eliminates three lines of javascript.

## How To Test

Expanding card should display Edit: Users, Name as before.

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [ ] Updated the docs, if necessary
- [x] Included the appropriate labels
- [ ] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)
- [x] ARE YOU MERGING INTO THE CORRECT BRANCH!?

Browsers tested:

- [x] Chrome
- [ ] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer

## Dependencies

- [ ] any other PRs or issues that should be resolved/merged before this is merged
