### PR TITLE
Onboard Project: got rid of collapse on edit/save

### DIFF
--- a/src/user-list/user-list.js
+++ b/src/user-list/user-list.js
@@ -119,7 +119,7 @@ class UserListElement extends PolymerElement {
       this.sortDirectionIsReversed
     );
 
-    this.resetExpandedCardIds(true);
+    this.resetExpandedCardIds();
   }
 
   sortByDirection(e) {
@@ -130,11 +130,11 @@ class UserListElement extends PolymerElement {
       this.sortDirectionIsReversed
     );
 
-    this.resetExpandedCardIds(true);
+    this.resetExpandedCardIds();
   }
 
-  resetExpandedCardIds(reset) {
-    this.expandedCardIds = reset ? [] : this.expandedCardIds;
+  resetExpandedCardIds() {
+    this.expandedCardIds = [];
   }
 
   addIdToExpandedList(id) {

--- a/src/user-list/user-list.js
+++ b/src/user-list/user-list.js
@@ -53,7 +53,7 @@ class UserListElement extends PolymerElement {
       }
     };
   }
-  
+
   connectedCallback() {
     super.connectedCallback();
 
@@ -89,17 +89,12 @@ class UserListElement extends PolymerElement {
 
   onUsersLoaded(response) {
     this.users = response.users;
-    let isEditSave = false;
 
     if (response.message) {
       const toastReset = '';
       this.toastMessage = toastReset;
       this.toastMessage = response.message;
-      const editInMessage = /edit/gi;
-      isEditSave = editInMessage.test(response.message);
     }
-
-    this.resetExpandedCardIds(isEditSave);
   }
 
   formatSortSelectionForDatabase(selected) {


### PR DESCRIPTION
## What It Does

Changes the display change on an edit save of an existing user. 

Previously this collapsed ALL cards when there was an edit save. This causes all cards to persist whatever state they were in (Except for the edit save, which is collapsed).

## How To Test

Open the details of a few users. Edit a user and change all information. Save the changes. All expanded users should still be expanded.

## Notes/Caveats

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [ ] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [ ] Updated the docs, if necessary
- [x] Included the appropriate labels
- [ ] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)
- [x] ARE YOU MERGING INTO THE CORRECT BRANCH!?

Browsers tested:

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer

## Dependencies

- [ ] any other PRs or issues that should be resolved/merged before this is merged
