### PR TITLE
Onboarding Project: Refactor – Reset Expanded Ids 

### DIFF
--- a/src/user-list/user-list.js
+++ b/src/user-list/user-list.js
@@ -119,7 +119,7 @@ class UserListElement extends PolymerElement {
       this.sortDirectionIsReversed
     );
 
-    this.resetExpandedCardIds(true);
+    this.resetExpandedCardIds();
   }
 
   sortByDirection(e) {
@@ -130,11 +130,11 @@ class UserListElement extends PolymerElement {
       this.sortDirectionIsReversed
     );
 
-    this.resetExpandedCardIds(true);
+    this.resetExpandedCardIds();
   }
 
-  resetExpandedCardIds(reset) {
-    this.expandedCardIds = reset ? [] : this.expandedCardIds;
+  resetExpandedCardIds() {
+    this.expandedCardIds = [];
   }
 
   addIdToExpandedList(id) {

--- a/src/user-list/user-list.js
+++ b/src/user-list/user-list.js
@@ -53,7 +53,7 @@ class UserListElement extends PolymerElement {
       }
     };
   }
-  
+
   connectedCallback() {
     super.connectedCallback();
 
@@ -89,17 +89,12 @@ class UserListElement extends PolymerElement {
 
   onUsersLoaded(response) {
     this.users = response.users;
-    let isEditSave = false;
 
     if (response.message) {
       const toastReset = '';
       this.toastMessage = toastReset;
       this.toastMessage = response.message;
-      const editInMessage = /edit/gi;
-      isEditSave = editInMessage.test(response.message);
     }
-
-    this.resetExpandedCardIds(isEditSave);
   }
 
   formatSortSelectionForDatabase(selected) {


### PR DESCRIPTION
## What It Does

Takes the boolean argument out of resetExpandedCardIds. 

Previously I used a boolean call for a case where I would or wouldn't want the ids reset from another function, but it was silly to put that as an argument rather than an if statement. 

Now resetExpandedCardIds just resets the id array whenever it's called

## How To Test

Sort users. Expanded cards should collapse.

## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [ ] Updated the docs, if necessary
- [x] Included the appropriate labels
- [x] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)
- [x] ARE YOU MERGING INTO THE CORRECT BRANCH!?

Browsers tested:

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer

## Dependencies

- [ ] None
