### PR TITLE
Onboarding Project: Bux Fix — Disable Sort When Edit Is Open

### DIFF
--- a/src/api/user-database.js
+++ b/src/api/user-database.js
@@ -100,7 +100,7 @@ export class Database {
     };
 
     await fetch(requestUrl, settings);
-    this.getUsersSortedBy(sortSettings.lastSort);
+    this.getUsersSortedBy(sortSettings.lastSort, sortSettings.isReversedSort);
   }
 
   static sendUsers(users) {

--- a/src/user-list/dropdown-list.html
+++ b/src/user-list/dropdown-list.html
@@ -92,13 +92,13 @@
       }
     </style>
 
-    <div class="dropdown-container">
+    <div rel$="[[isDisabled(disabled)]]" class="dropdown-container">
       <div class="dropdown-header">Sort Users By:
       </div>
       <hr>
       <div class="dropdown-options">
         <template is="dom-repeat" items="[[listItems]]">
-          <li id="lastName" on-click="setArrow">[[item]]
+          <li id="lastName" on-click="setCheckedItem">[[item]]
             <template is="dom-if" if="[[sortIs(item, selectedItem)]]">
               ✓
             </template>
@@ -123,6 +123,9 @@
           },
           selectedItem: {
             type: String,
+          },
+          disabled: {
+            type: Boolean,
           }
         };
       }
@@ -136,12 +139,16 @@
         this.selectedItem = this.listItems[0];
       }
 
-      setArrow(e) {
-        this.selectedItem = e.model.item;
+      setCheckedItem(e) {
+          this.selectedItem = e.model.item;
       }
 
       sortIs(current, expected) {
         return current === expected;
+      }
+
+      isDisabled() {
+        return this.disabled ? 'dropdown-disabled' : 'dropdown-enabled';
       }
     }
 

--- a/src/user-list/dropdown-list.html
+++ b/src/user-list/dropdown-list.html
@@ -38,7 +38,16 @@
         transition: opacity .3s;
       }
 
-      .dropdown-container:hover>hr {
+      .dropdown-container[rel*="disabled"] {
+        opacity: .5;
+      }
+      .dropdown-container[rel*="disabled"]>.dropdown-options>li {
+        visibility: hidden;
+      }
+
+
+
+      [rel="dropdown-enabled"]:hover>hr {
         margin-bottom: 5px;
         opacity: 1;
         transition: opacity .2s;
@@ -50,13 +59,13 @@
         transition: max-height .3s ease-out;
       }
 
-      .dropdown-container:hover>.dropdown-options {
+      [rel="dropdown-enabled"]:hover>.dropdown-options {
         max-height: 100px;
         transition: max-height .3s;
         opacity: 1;
       }
 
-      .dropdown-container:hover>.dropdown-options>li {
+      [rel="dropdown-enabled"]:hover>.dropdown-options>li {
         list-style: none;
         opacity: 1;
         transition: opacity .2s .1s;

--- a/src/user-list/dropdown-list.html
+++ b/src/user-list/dropdown-list.html
@@ -140,7 +140,7 @@
       }
 
       setCheckedItem(e) {
-          this.selectedItem = e.model.item;
+        this.selectedItem = e.model.item;
       }
 
       sortIs(current, expected) {

--- a/src/user-list/user-list.html
+++ b/src/user-list/user-list.html
@@ -79,8 +79,8 @@
         <div class="create-user-row">
           <user-component class="new-user-card" edit-open="[[editInProgress]]"></user-component>
           <div class="options-bar">
-            <dropdown-list class="sort-category-dropdown" on-click="dropdownSort" selected-item list-items="[[sortCategoryOptions]]"></dropdown-list>
-            <dropdown-list class="sort-direction-dropdown" on-click="sortByDirection" selected-item list-items="[[sortDirectionOptions]]">
+            <dropdown-list disabled="[[editInProgress]]" class="sort-category-dropdown" on-click="dropdownSort" selected-item list-items="[[sortCategoryOptions]]"></dropdown-list>
+            <dropdown-list disabled="[[editInProgress]]" class="sort-direction-dropdown" on-click="sortByDirection" selected-item list-items="[[sortDirectionOptions]]">
             </dropdown-list>
           </div>
         </div>

--- a/src/user-list/user-list.js
+++ b/src/user-list/user-list.js
@@ -110,27 +110,31 @@ class UserListElement extends PolymerElement {
   }
 
   dropdownSort(e) {
-    this.currentSortCategory = this.formatSortSelectionForDatabase(
-      e.target.selectedItem
-    );
+    if (!this.editInProgress) {
+      this.currentSortCategory = this.formatSortSelectionForDatabase(
+        e.target.selectedItem
+      );
 
-    Database.getUsersSortedBy(
-      this.currentSortCategory,
-      this.sortDirectionIsReversed
-    );
+      Database.getUsersSortedBy(
+        this.currentSortCategory,
+        this.sortDirectionIsReversed
+      );
 
-    this.resetExpandedCardIds();
+      this.resetExpandedCardIds();
+    }
   }
 
   sortByDirection(e) {
-    this.sortDirectionIsReversed = e.target.selectedItem === 'Z-A';
+    if (!this.editInProgress) {
+      this.sortDirectionIsReversed = e.target.selectedItem === 'Z-A';
 
-    Database.getUsersSortedBy(
-      this.currentSortCategory,
-      this.sortDirectionIsReversed
-    );
+      Database.getUsersSortedBy(
+        this.currentSortCategory,
+        this.sortDirectionIsReversed
+      );
 
-    this.resetExpandedCardIds();
+      this.resetExpandedCardIds();
+    }
   }
 
   resetExpandedCardIds() {


### PR DESCRIPTION
## What It Does

This disables the dropdown sort feature when a user edit is in progress.

Colin caught a bug that when you sort while a user edit is in progress, it locks the user card in a collapsed edit mode.

I added a 'disabled/enabled' rel to the dropdown sort and targeted that with CSS to show when the dropdown is disabled.

I also added an if(!editInProgress) statement at the beginning of both sort functions to block in the event that someone tries to click the dropdown menus anyway.

## How To Test

Open an edit, try to sort. 

Save the edit, try to sort.

## Notes/Caveats


## Checklist

Under penalty of public shaming, I avow that I:

- [x] Reviewed the diff to look for typos, whitespace errors, and console.log() statements
- [x] Verified that there are no compiler or linter errors or warnings
- [ ] Verified the build in production(optimized) mode
- [ ] Updated the docs, if necessary
- [x] Included the appropriate labels
- [ ] Referenced applicable issues (i.e. Closes #XXXX, Fixes #XXXX)
- [x] ARE YOU MERGING INTO THE CORRECT BRANCH!?

Browsers tested:

- [x] Chrome
- [x] Firefox
- [ ] Safari
- [ ] Edge
- [ ] Internet Explorer

## Dependencies

- [ ] any other PRs or issues that should be resolved/merged before this is merged
